### PR TITLE
Added ability to override the /etc/resolve.conf file at startup.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ ADD transmission/runUpdates.sh /etc/transmission-daemon/startPortUpdates.sh
 ADD transmission/down.sh /etc/transmission-daemon/stop.sh
 ADD runOpenVpn.sh /etc/openvpn/start.sh
 
+# Optional resolv.conf override
+ENV RESOLV_OVERRIDE **None**
+
 # Expose port and run. Use baseimage-docker's init system
 EXPOSE 9091
 CMD ["/etc/openvpn/start.sh"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ The only mandatory configuration is a pia-credentials.txt file that needs to be 
 
 NB: Instructions on how to use your own Transmission settings, and how to connect to the WebUI, is further down in the README.
 
+## Environment options
+| Variable | Function | Example |
+|----------|----------|-------|
+|`RESOLV_OVERRIDE` | The value of this variable will be written to `/etc/resolv.conf`. | "RESOLV_OVERRIDE=nameserver 8.8.8.8\nnameserver 8.8.4.4\n"|
+
 # Building the container yourself
 To build this container, clone the repository and cd into it.
 

--- a/runOpenVpn.sh
+++ b/runOpenVpn.sh
@@ -1,3 +1,9 @@
 #!/bin/sh
 
+if [ "$RESOLV_OVERRIDE" != "**None**" ];
+then
+  echo "Overriding resolv.conf..."
+  printf "$RESOLV_OVERRIDE" > /etc/resolv.conf
+fi
+
 exec openvpn --config /etc/openvpn/config.ovpn


### PR DESCRIPTION
I fixed my issue with the DNS resolution by adding an optional ENV VAR that will replace the `/etc/resolv.conf` at start up.

This should fix #4

I added a section in the readme related to this env var, and sets up a section for new env vars.