### PR TITLE
Fix entropy error, enable transmission logging

### DIFF
--- a/transmission/start.sh
+++ b/transmission/start.sh
@@ -13,7 +13,9 @@ mkdir -p ${TRANSMISSION_HOME}
 dockerize -template /etc/transmission/settings.tmpl:${TRANSMISSION_HOME}/settings.json /bin/true
 
 echo "STARTING TRANSMISSION"
-exec /usr/bin/transmission-daemon -g ${TRANSMISSION_HOME} &
+# Avoid "Fatal: no entropy gathering module detected" error
+ln -s /dev/urandom /dev/random
+exec /usr/bin/transmission-daemon -g ${TRANSMISSION_HOME} --logfile ${TRANSMISSION_HOME}/transmission.log &
 
 if [ "$OPENVPN_PROVIDER" = "PIA" ]
 then


### PR DESCRIPTION
Fix for issue outlined in https://github.com/haugene/docker-transmission-openvpn/issues/36

Also slipped in a —logfile param so transmission will log to disk.