### PR TITLE
Add a link from nginx to openvpn in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ http {
 }
 ```
 Your Transmission WebUI should now be avaliable at "your.host.ip.addr:8080/transmission/web/".
-Change the port in the docker run command if 8080 is not suitable for you.
+Change the port in the docker run command if 8080 is not suitable for you. Alternatively if you use container linking, either directly or via docker-compose, you can replace "your.host.ip.addr" with the name or alias of the openvpn container.
 
 ## Known issues
 Some have encountered problems with DNS resolving inside the docker container.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ openvpn:
 
 nginx:
   image: library/nginx
+  links:
+    - openvpn
   ports:
      - "8080:8080"
   volumes:


### PR DESCRIPTION
I had some trouble getting nginx to reverse-proxy to transmission using my local IP address. The solution in the end was to add a link from the nginx container to the openvpn container. This causes docker-compose to map the name 'openvpn' to the IP address of the actual container at start up.

This would also allow you to include a portable nginx.conf file in the repository that didn't require the user to change anything. Let me know if you would like me to open a second pull request adding a copy of my nginx.conf that works with this.