### PR TITLE
systemd integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN apt-get update \
     && apt-get update \
     && apt-get install -y transmission-cli transmission-common transmission-daemon \
     && apt-get install -y openvpn curl rar unrar zip unzip \
+    && curl -sLO https://github.com/Yelp/dumb-init/releases/download/v1.0.1/dumb-init_1.0.1_amd64.deb \
+    && dpkg -i dumb-init_*.deb \
+    && rm -rf dumb-init_*.deb \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && curl -L https://github.com/jwilder/dockerize/releases/download/v0.0.2/dockerize-linux-amd64-v0.0.2.tar.gz | tar -C /usr/local/bin -xzv
 
@@ -101,4 +104,4 @@ ENV OPENVPN_USERNAME=**None** \
 
 # Expose port and run
 EXPOSE 9091
-CMD ["/etc/openvpn/start.sh"]
+CMD ["dumb-init", "/etc/openvpn/start.sh"]

--- a/README.md
+++ b/README.md
@@ -174,9 +174,11 @@ For example, another container may pause or restrict transmission speeds while t
 
 On many modern linux systems, including Ubuntu, systemd can be used to start the transmission-openvpn at boot time, and restart it after any failure.
 
-Save the following as `/etc/systemd/system/transmission-openvpn.service`.
+Save the following as `/etc/systemd/system/transmission-openvpn.service`, and replace the OpenVPN PROVIDER/USERNAME/PASSWORD directives with your settings, and add any other directives that you're using.
 
-It's assuming that there is a `bittorrent` user set up with a home directory at `/home/bittorrent/`. The data directory will be mounted at `/home/bittorrent/data/`, and OpenVPN is set to exit if there is a connection failure. OpenVPN exiting triggers the container to also exit, then the `Restart=always` definition in the `transmission-openvpn.service` file tells systems to restart things again.
+This service is assuming that there is a `bittorrent` user set up with a home directory at `/home/bittorrent/`. The data directory will be mounted at `/home/bittorrent/data/`. This can be changed to whichever user and location you're using.
+
+OpenVPN is set to exit if there is a connection failure. OpenVPN exiting triggers the container to also exit, then the `Restart=always` definition in the `transmission-openvpn.service` file tells systems to restart things again.
 
 ```
 [Unit]

--- a/README.md
+++ b/README.md
@@ -220,6 +220,14 @@ $ sudo systemctl enable /etc/systemd/system/transmission-openvpn.service
 $ sudo systemctl restart transmission-openvpn.service
 ```
 
+If it is stopped or killed in any fashion, systemd will restart the container. If you do want to shut it down, then run the following command and it will stay down until you restart it.
+
+```
+$ sudo systemctl stop transmission-openvpn.service
+# Later ...
+$ sudo systemctl start transmission-openvpn.service
+```
+
 ## Make it work on Synology NAS
 Here are the steps to run it on a Synology NAS (Tested on DSM 6) :
 


### PR DESCRIPTION
Re: #69 

README changes explaining about systemd integration.
Plus Dockerfile change to install and use Yelp's dumb-init to avoid zombies.

I notice that there is a new version of dumb-init release since I started using it 12 days ago but I left the Dockerfile with v1.0.1, as that's the one I've been testing.

Cheers,

Dave