### PR TITLE
Add support for local network route

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ By default a folder named transmission-home will also be created under /data, th
 |----------|----------|-------|
 |`OPENVPN_CONFIG` | Sets the OpenVPN endpoint to connect to. | `OPENVPN_CONFIG=UK Southampton`|
 |`OPENVPN_OPTS` | Will be passed to OpenVPN on startup | See [OpenVPN doc](https://openvpn.net/index.php/open-source/documentation/manuals/65-openvpn-20x-manpage.html) |
+|`LOCAL_NETWORK` | Sets the local network that should have access. | `LOCAL_NETWORK=192.168.0.0/24`|
 
 ### Transmission configuration options
 
@@ -81,7 +82,7 @@ This is because the VPN is active, and since docker is running in a different ip
 to your request will be treated as "non-local" traffic and therefore be routed out through the VPN interface.
 
 ### How to fix this
-There are several ways to fix this. You can pipe and do fancy iptables or ip route configurations on the host and in the container. But I found that the simplest solution is just to proxy my traffic.
+There are several ways to fix this. The container supports the `LOCAL_NETWORK` environment variable. For instance if your local network uses the IP range 192.168.0.0/24 you would pass `-e LOCAL_NETWORK=192.168.0.0/24`. Alternatively just proxy the traffic.
 
 #### Use preconfigured image
 You can use the proxy image haugene/transmission-openvpn-proxy that comes with a config that is configurable through environment variables.

--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -x
 vpn_provider="$(echo $OPENVPN_PROVIDER | tr '[A-Z]' '[a-z]')"
 vpn_provider_configs="/etc/openvpn/$vpn_provider"
 if [ ! -d "$vpn_provider_configs" ]; then

--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -47,4 +47,12 @@ dockerize -template /etc/transmission/environment-variables.tmpl:/etc/transmissi
 
 TRANSMISSION_CONTROL_OPTS="--script-security 2 --up /etc/transmission/start.sh --down /etc/transmission/stop.sh"
 
+if [ -n "${LOCAL_NETWORK-}" ]; then
+  eval $(/sbin/ip r l m 0.0.0.0 | awk '{if($5!="tun0"){print "GW="$3"\nINT="$5; exit}}')
+  if [ -n "${GW-}" -a -n "${INT-}" ]; then
+    echo "adding route to local network $LOCAL_NETWORK via $GW dev $INT"
+    /sbin/ip r a "$LOCAL_NETWORK" via "$GW" dev "$INT"
+  fi
+fi
+
 exec openvpn $TRANSMISSION_CONTROL_OPTS $OPENVPN_OPTS --config "$OPENVPN_CONFIG"


### PR DESCRIPTION
This PR adds support for e.g. `-e LOCAL_NETWORK=10.0.0.0/24` so the container stays available on the local network and access doesn't require a proxy.