### PR TITLE
added support for uid/gid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,11 @@ RUN apt-get update \
     && dpkg -i dumb-init_*.deb \
     && rm -rf dumb-init_*.deb \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && curl -L https://github.com/jwilder/dockerize/releases/download/v0.0.2/dockerize-linux-amd64-v0.0.2.tar.gz | tar -C /usr/local/bin -xzv
+    && curl -L https://github.com/jwilder/dockerize/releases/download/v0.0.2/dockerize-linux-amd64-v0.0.2.tar.gz | tar -C /usr/local/bin -xzv \
+    && groupmod -g 1000 users \
+    && useradd -u 911 -U -d /config -s /bin/false abc \
+    && usermod -G users abc
 
-# Add configuration and scripts
 ADD openvpn/ /etc/openvpn/
 ADD transmission/ /etc/transmission/
 
@@ -100,7 +102,9 @@ ENV OPENVPN_USERNAME=**None** \
     "TRANSMISSION_UTP_ENABLED=true" \
     "TRANSMISSION_WATCH_DIR=/data/watch" \
     "TRANSMISSION_WATCH_DIR_ENABLED=true" \
-    "TRANSMISSION_HOME=/data/transmission-home"
+    "TRANSMISSION_HOME=/data/transmission-home" \
+    PUID=\
+    PGID=
 
 # Expose port and run
 EXPOSE 9091

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -16,7 +16,10 @@ RUN apt-get update \
     && dpkg -i dumb-init_*.deb \
     && rm -rf dumb-init_*.deb \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && curl -L https://github.com/jwilder/dockerize/releases/download/v0.2.0/dockerize-linux-armhf-v0.2.0.tar.gz | tar -C /usr/local/bin -xzv
+    && curl -L https://github.com/jwilder/dockerize/releases/download/v0.2.0/dockerize-linux-armhf-v0.2.0.tar.gz | tar -C /usr/local/bin -xzv \
+    && groupmod -g 1000 users \
+    && useradd -u 911 -U -d /config -s /bin/false abc \
+    && usermod -G users abc
 
 # Add configuration and scripts
 ADD openvpn/ /etc/openvpn/
@@ -96,7 +99,9 @@ ENV OPENVPN_USERNAME=**None** \
     "TRANSMISSION_UTP_ENABLED=true" \
     "TRANSMISSION_WATCH_DIR=/data/watch" \
     "TRANSMISSION_WATCH_DIR_ENABLED=true" \
-    "TRANSMISSION_HOME=/data/transmission-home"
+    "TRANSMISSION_HOME=/data/transmission-home" \
+    PUID=\
+    PGID=
 
 # Expose port and run
 EXPOSE 9091

--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ As you can see the variables are prefixed with `TRANSMISSION_`, the variable is 
 PS: `TRANSMISSION_BIND_ADDRESS_IPV4` will be overridden to the IP assigned to your OpenVPN tunnel interface.
 This is to prevent leaking the host IP.
 
+### User configuration options
+
+By default everything will run as the root user. However, it is possible to change who runs the transmission process. 
+You may set the following parameters to customize the user id that runs transmission.
+
+| Variable | Function | Example |
+|----------|----------|-------|
+|`PUID` | Sets the user id who will run transmission | `PUID=1003`|
+|`PGID` | Sets the group id for the transmission user | `PGID=1003` |
+
 ## Access the WebUI
 But what's going on? My http://my-host:9091 isn't responding?
 This is because the VPN is active, and since docker is running in a different ip range than your client the response

--- a/transmission/environment-variables.tmpl
+++ b/transmission/environment-variables.tmpl
@@ -74,3 +74,6 @@ export TRANSMISSION_WATCH_DIR_ENABLED={{ .Env.TRANSMISSION_WATCH_DIR_ENABLED }}
 
 # Transmission needs to know which VPN provider is used
 export OPENVPN_PROVIDER={{ .Env.OPENVPN_PROVIDER }}
+
+export PUID={{ .Env.PUID }}
+export PGID={{ .Env.PGID }}

--- a/transmission/start.sh
+++ b/transmission/start.sh
@@ -19,8 +19,10 @@ if [ ! -e "/dev/random" ]; then
   ln -s /dev/urandom /dev/random
 fi
 
+. /etc/transmission/userSetup.sh
+
 echo "STARTING TRANSMISSION"
-exec /usr/bin/transmission-daemon -g ${TRANSMISSION_HOME} --logfile ${TRANSMISSION_HOME}/transmission.log &
+exec sudo -u ${RUN_AS} /usr/bin/transmission-daemon -g ${TRANSMISSION_HOME} --logfile ${TRANSMISSION_HOME}/transmission.log &
 
 if [ "$OPENVPN_PROVIDER" = "PIA" ]
 then

--- a/transmission/userSetup.sh
+++ b/transmission/userSetup.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# More/less taken from https://github.com/linuxserver/docker-baseimage-alpine/blob/3eb7146a55b7bff547905e0d3f71a26036448ae6/root/etc/cont-init.d/10-adduser
+
+RUN_AS=root
+
+if [ -n "$PUID" ] && [ ! "$(id -u root)" -eq "$PUID" ]; then
+    RUN_AS=abc
+    if [ ! "$(id -u ${RUN_AS})" -eq "$PUID" ]; then usermod -o -u "$PUID" ${RUN_AS} ; fi
+    if [ ! "$(id -g ${RUN_AS})" -eq "$PGID" ]; then groupmod -o -g "$PGID" ${RUN_AS} ; fi
+
+    echo "Setting owner for transmission paths to ${PUID}:${PGID}"
+    chown -R ${RUN_AS}:${RUN_AS} ${TRANSMISSION_HOME}
+    chown ${RUN_AS}:${RUN_AS} \
+        /config \
+        ${TRANSMISSION_DOWNLOAD_DIR} \
+        ${TRANSMISSION_INCOMPLETE_DIR} \
+        ${TRANSMISSION_WATCH_DIR}
+fi
+
+echo "
+-------------------------------------
+Transmission will run as
+-------------------------------------
+User name:   ${RUN_AS}
+User uid:    $(id -u ${RUN_AS})
+User gid:    $(id -g ${RUN_AS})
+-------------------------------------
+"
+
+export PUID
+export PGID
+export RUN_AS


### PR DESCRIPTION
By default transmission will still run as root so as to not break backwards compatibility.

This should address issue #89, though it doesn't do the auto detect the existing files thing that was suggested as a neat feature.