### PR TITLE
Added more robust error handling around checking for new port from PIA

### DIFF
--- a/transmission/updatePort.sh
+++ b/transmission/updatePort.sh
@@ -31,10 +31,27 @@ if [ -z ${pia_client_id} ]; then
 fi
 
 # Get the port
-pia_response=$(curl -d "user=$pia_username&pass=$pia_passwd&client_id=$pia_client_id&local_ip=$local_vpn_ip" $port_assignment_url)
+pia_response=$(curl -s -f -d "user=$pia_username&pass=$pia_passwd&client_id=$pia_client_id&local_ip=$local_vpn_ip" $port_assignment_url)
 
+# Check for curl error (curl will fail on HTTP errors with -f flag)
+if [ $? -ne 0 ]; then
+     echo "Encountered an error looking up new port: $?"
+fi
+
+# Check for errors in PIA response
+error=$(echo $pia_response | grep -oE "\"error\".*\"")
+if [ ! -z "$error" ]; then
+     echo "PIA returned an error: $error"
+     exit
+fi
+
+# Get new port, check if empty
 new_port=$(echo $pia_response | grep -oE "[0-9]+")
-echo "Got new port $new_port from pia"
+if [ -z "$new_port" ]; then
+    echo "Could not find new port from PIA"
+    exit
+fi
+echo "Got new port $new_port from PIA"
 
 #
 # Now, set port in Transmission
@@ -61,4 +78,3 @@ if [ "$new_port" != "$transmission_peer_port" ]
   else
     echo "No action needed, port hasn't changed"
 fi
-

--- a/transmission/updatePort.sh
+++ b/transmission/updatePort.sh
@@ -34,8 +34,9 @@ fi
 pia_response=$(curl -s -f -d "user=$pia_username&pass=$pia_passwd&client_id=$pia_client_id&local_ip=$local_vpn_ip" $port_assignment_url)
 
 # Check for curl error (curl will fail on HTTP errors with -f flag)
-if [ $? -ne 0 ]; then
-     echo "Encountered an error looking up new port: $?"
+ret=$?
+if [ $ret -ne 0 ]; then
+     echo "curl encountered an error looking up new port: $ret"
 fi
 
 # Check for errors in PIA response


### PR DESCRIPTION
Hi, 

After experiencing port issues in #167, I tracked down what might be causing them. In my experience, the curl request to PIA would timeout, and the `updatePort.sh` script wouldn't handle that error properly, and proceed to set an empty port to transmission which resolved to port 0.

I added some additional error checks to make sure we've got a port from PIA before setting it, as well as fail if curl receives an HTTP error. I also made the curl downloading output silent, as it was cluttering up logs.

Hope this helps, please let me know if I should make any changes!