### PR TITLE
Fix docker-compose errors and introduce image names

### DIFF
--- a/docker-compose-armhf.yml
+++ b/docker-compose-armhf.yml
@@ -5,6 +5,7 @@ services:
   build: 
      context: .
      dockerfile: Dockerfile.armhf
+  image: haugene/rpi-transmission-openvpn
   privileged: true
   restart: always
   ports:
@@ -19,11 +20,14 @@ services:
     - OPENVPN_PROVIDER=PIA
     - OPENVPN_USERNAME=username
     - OPENVPN_PASSWORD=password
-    - OPENVPN_OPTS="--inactive 3600 --ping 10 --ping-exit 60"
+    - OPENVPN_OPTS=--inactive 3600 --ping 10 --ping-exit 60
     - LOCAL_NETWORK=192.168.0.0/24
 
  proxy:
-  build: ./proxy/Dockerfile.armhf
+  build:
+     context: ./proxy
+     dockerfile: Dockerfile.armhf
+  image: haugene/rpi-transmission-openvpn-proxy
   links:
     - transmission
   ports:


### PR DESCRIPTION
- Removed double quotes from the "OPENVPN_OPTS=" line due to literal interpretation that would cause an issue at /openvpn/start.sh:57 when executed.
- Fixed failing "proxy/build" instruction. Splitting into "context" and "dockerfile" subkeys prevents the error "TypeError: You must specify a directory to build in path"
- [Proposal] Introduced "image: haugene/rpi-transmission-openvpn*" lines to each docker-compose structure to transition to Docker Hub hosted images in the future. (see https://resin.io/blog/building-arm-containers-on-any-x86-machine-even-dockerhub/)