### PR TITLE
Reduce the amount of privileges needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The container is available from the Docker registry and this is the simplest way
 To run the container use this command:
 
 ```
-$ docker run --privileged  -d \
+$ docker run --cap-add=NET_ADMIN --device=/dev/net/tun -d \
               -v /your/storage/path/:/data \
               -v /etc/localtime:/etc/localtime:ro \
               -e "OPENVPN_PROVIDER=PIA" \
@@ -117,7 +117,7 @@ Please note that if you pass in env. variables on the command line these will ov
 See explanation of variables above.
 To use this env file, use the following to run the docker image:
 ```
-$ docker run --privileged  -d \
+$ docker run --cap-add=NET_ADMIN --device=/dev/net/tun -d \
               -v /your/storage/path/:/data \
               -v /etc/localtime:/etc/localtime:ro \
               --env-file /your/docker/env/file \
@@ -233,7 +233,7 @@ nameserver 8.8.8.8
 nameserver 8.8.4.4
 ```
 - Save the file with [escape] + `:wq!`
-- Create your docker container with a classic command like `docker run --privileged -d -v /volume1/foldername/resolv.conf:/etc/resolv.conf -v /volume1/yourpath/:/data -e "OPENVPN_PROVIDER=PIA" -e "OPENVPN_CONFIG=Netherlands" -e "OPENVPN_USERNAME=XXXXX" -e "OPENVPN_PASSWORD=XXXXX" -p 9091:9091 --name "TransmissionVPN" haugene/transmission-openvpn`
+- Create your docker container with a classic command like `docker run --cap-add=NET_ADMIN --device=/dev/net/tun -d -v /volume1/foldername/resolv.conf:/etc/resolv.conf -v /volume1/yourpath/:/data -e "OPENVPN_PROVIDER=PIA" -e "OPENVPN_CONFIG=Netherlands" -e "OPENVPN_USERNAME=XXXXX" -e "OPENVPN_PASSWORD=XXXXX" -p 9091:9091 --name "TransmissionVPN" haugene/transmission-openvpn`
 - To make it work after a nas restart, create an automated task in your synology web interface : go to **Settings Panel > Task Scheduler ** create a new task that run `/volume1/foldername/TUN.sh` as root (select '_root_' in 'user' selectbox). This task will start module that permit the container to run, you can make a task that run on startup. These kind of task doesn't work on my nas so I just made a task that run every minute.
 - Enjoy
 
@@ -261,7 +261,8 @@ ExecStartPre=-/usr/bin/docker rm transmission-openvpn
 ExecStartPre=/usr/bin/docker pull haugene/transmission-openvpn
 ExecStart=/usr/bin/docker run \
         --name transmission-openvpn \
-        --privileged \
+        --cap-add=NET_ADMIN \
+        --device=/dev/net/tun \
         -v /home/bittorrent/data/:/data \
         -e "OPENVPN_PROVIDER=TORGUARD" \
         -e "OPENVPN_USERNAME=bittorrent@example.com" \

--- a/docker-compose-armhf.yml
+++ b/docker-compose-armhf.yml
@@ -2,11 +2,14 @@ version: '2'
 
 services:
  transmission:
-  build: 
+  build:
      context: .
      dockerfile: Dockerfile.armhf
   image: haugene/rpi-transmission-openvpn
-  privileged: true
+  cap_add:
+    - NET_ADMIN
+  devices:
+    - "/dev/net/tun"
   restart: always
   ports:
     - "9091:9091"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,10 @@ version: '2'
 services:
  transmission:
   image: haugene/transmission-openvpn
-  privileged: true
+  cap_add:
+    - NET_ADMIN
+  devices:
+    - "/dev/net/tun"
   restart: always
   ports:
     - "9091:9091"


### PR DESCRIPTION
Thought it'd be nice for various security reasons to reduce how many privileges this container has. Running with only the necessary privileges also makes it possible to use user namespaces (you need `--userns="host"` if you're using `--privileged`).