### PR TITLE
restart openvpn if the up script is executed and no ipv4 is bound 

### DIFF
--- a/transmission/start.sh
+++ b/transmission/start.sh
@@ -5,6 +5,13 @@
 
 # This script will be called with tun/tap device name as parameter 1, and local IP as parameter 4
 # See https://openvpn.net/index.php/open-source/documentation/manuals/65-openvpn-20x-manpage.html (--up cmd)
+echo "Up script executed with $*"
+if [ "$4" = "" ]; then
+   echo "ERROR, unable to obtain tunnel address"
+   echo "killing $PPID"
+   kill -9 $PPID
+   exit 1
+fi
 echo "Updating TRANSMISSION_BIND_ADDRESS_IPV4 to the ip of $1 : $4"
 export TRANSMISSION_BIND_ADDRESS_IPV4=$4
 


### PR DESCRIPTION
During testing with PureVPN, there are some situations where the up script is executed when a VPN tunnel is not actually established.  See log sample below.   This script update will kill the openvpn and have the tunnel re-established when this occurs rather then starting transmission with no VPN tunnel established

```
Thu Nov 30 14:55:38 2017 TUN/TAP device tun0 opened
Thu Nov 30 14:55:38 2017 /etc/transmission/start.sh tun0 1500 1558   init
Up script executed with tun0 1500 1558   init
ERROR, unable to obtain tunnel address
```