### PR TITLE
Allow a pre-existing /config/openvpn-credentials.txt file.

### DIFF
--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -27,8 +27,11 @@ fi
 
 # add OpenVPN user/pass
 if [ "${OPENVPN_USERNAME}" = "**None**" ] || [ "${OPENVPN_PASSWORD}" = "**None**" ] ; then
- echo "OpenVPN credentials not set. Exiting."
- exit 1
+  if [ ! -f /config/openvpn-credentials.txt ] ; then
+    echo "OpenVPN credentials not set. Exiting."
+    exit 1
+  fi
+  echo "Found existing OPENVPN credentials..."
 else
   echo "Setting OPENVPN credentials..."
   mkdir -p /config


### PR DESCRIPTION
Instead of bailing when the OpenVPN user and password aren't defined in the environment, we should instead check and see if we already have an existing /config/openvpn-credentials.txt file from a persistent volume that can be used first.

This is important because --link will share environment variables with other containers, and it would be preferable to not need to include external auth information with that.