### PR TITLE
add option to drop the default route on providers, that do not override it properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,3 +367,12 @@ $ sudo systemctl stop transmission-openvpn.service
 # Later ...
 $ sudo systemctl start transmission-openvpn.service
 ```
+
+## Drop the default route
+
+Some VPNs do not override the default route, but rather set other routes with a lower metric.  
+This might lead to te default route (your untunneled connection) to be used.
+
+To drop the default route set the environment variable `DROP_DEFAULT_ROUTE` to `true`.
+
+*Note*: This is not compatible with all VPNs. Please check yourself if your provider overrides the default route properly.

--- a/transmission/environment-variables.tmpl
+++ b/transmission/environment-variables.tmpl
@@ -81,3 +81,6 @@ export PGID={{ .Env.PGID }}
 
 # Support custom web frontend
 {{ if .Env.TRANSMISSION_WEB_HOME }} export TRANSMISSION_WEB_HOME={{ .Env.TRANSMISSION_WEB_HOME }} {{end}}
+
+# Support dropping the default route after connection
+export DROP_DEFAULT_ROUTE={{ .Env.DROP_DEFAULT_ROUTE }}

--- a/transmission/start.sh
+++ b/transmission/start.sh
@@ -38,6 +38,11 @@ fi
 
 . /etc/transmission/userSetup.sh
 
+if [ "true" = "$DROP_DEFAULT_ROUTE" ]; then
+  echo "DROPPING DEFAULT ROUTE"
+  ip r del default || exit 1
+fi
+
 echo "STARTING TRANSMISSION"
 exec sudo -E -u ${RUN_AS} /usr/bin/transmission-daemon -g ${TRANSMISSION_HOME} --logfile ${TRANSMISSION_HOME}/transmission.log &
 


### PR DESCRIPTION
I discovered that with some VPN providers (e.g. Mullvad) the routes have a potential issue.
This addresses this issue by allowing the user to drop the default route after OpenVPN has connected, but before Transmission is started.

Before:
```
root@62a71b505acd:/# ip r
0.0.0.0/1 via 10.8.0.1 dev tun0
default via 172.19.0.1 dev eth0
10.0.0.0/8 via 172.19.0.1 dev eth0
10.8.0.0/16 dev tun0  proto kernel  scope link  src 10.8.0.6
82.103.140.213 via 172.19.0.1 dev eth0
128.0.0.0/1 via 10.8.0.1 dev tun0
172.19.0.0/16 dev eth0  proto kernel  scope link  src 172.19.0.4

```

After (with `DROP_DEFAULT_ROUTE`=`true`:
```
root@e9150d61d626:/# ip r
0.0.0.0/1 via 10.8.0.1 dev tun0
10.0.0.0/8 via 172.19.0.1 dev eth0
10.8.0.0/16 dev tun0  proto kernel  scope link  src 10.8.0.8
128.0.0.0/1 via 10.8.0.1 dev tun0
134.90.149.138 via 172.19.0.1 dev eth0
172.19.0.0/16 dev eth0  proto kernel  scope link  src 172.19.0.4
```

In both cases `10.0.0.0/8` is my `LOCAL_NETWORK`.