### PR TITLE
Upgrade armhf image to debian stretch. This will remove the need for …

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM resin/rpi-raspbian:jessie
+FROM resin/rpi-raspbian:stretch
 MAINTAINER Kristian Haugene
 
 VOLUME /data
@@ -8,14 +8,11 @@ VOLUME /config
 RUN apt-get update \
     && apt-get -y upgrade \
     && apt-get -y install transmission-cli transmission-common transmission-daemon \
-    && apt-get install -y unzip openvpn curl ufw wget git \
+    && apt-get install -y dumb-init unzip openvpn curl ufw wget git \
     && wget https://github.com/Secretmapper/combustion/archive/release.zip \
     && unzip release.zip -d /opt/transmission-ui/ \
     && rm release.zip \
     && git clone git://github.com/endor/kettu.git /opt/transmission-ui/kettu \
-    && curl -sLO https://archive.raspbian.org/raspbian/pool/main/d/dumb-init/dumb-init_1.0.3-1_armhf.deb \
-    && dpkg -i dumb-init_*.deb \
-    && rm -rf dumb-init_*.deb \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && curl -L https://github.com/jwilder/dockerize/releases/download/v0.6.0/dockerize-linux-armhf-v0.6.0.tar.gz | tar -C /usr/local/bin -xzv \
     && groupmod -g 1000 users \


### PR DESCRIPTION
…a custom dumb-init as well as upgrade to the latest transmission.

Should resolve issue #392 for the arm platform.

Also works hand in hand with #395