### PR TITLE
Fix settings.json file attributes on Synology NAS.

### DIFF
--- a/transmission/start.sh
+++ b/transmission/start.sh
@@ -39,6 +39,14 @@ echo "Generating transmission settings.json from env variables"
 mkdir -p ${TRANSMISSION_HOME}
 dockerize -template /etc/transmission/settings.tmpl:${TRANSMISSION_HOME}/settings.json
 
+echo "Check transmission settings.json file attributes"
+SETTINGS_PATH=${TRANSMISSION_HOME}/settings.json
+SETTINGS_ATTRIBUTES=$(stat -c %a ${SETTINGS_PATH})
+if [ ${SETTINGS_ATTRIBUTES} = 0 ]; then
+  # Ensure settings.json have non zero attributes (actual for Synology NAS)
+  chmod 640 ${SETTINGS_PATH} && echo "INFO: Attributes of setting.json changed to 640"
+fi
+
 echo "sed'ing True to true"
 sed -i 's/True/true/g' ${TRANSMISSION_HOME}/settings.json
 

--- a/transmission/start.sh
+++ b/transmission/start.sh
@@ -39,14 +39,6 @@ echo "Generating transmission settings.json from env variables"
 mkdir -p ${TRANSMISSION_HOME}
 dockerize -template /etc/transmission/settings.tmpl:${TRANSMISSION_HOME}/settings.json
 
-echo "Check transmission settings.json file attributes"
-SETTINGS_PATH=${TRANSMISSION_HOME}/settings.json
-SETTINGS_ATTRIBUTES=$(stat -c %a ${SETTINGS_PATH})
-if [ ${SETTINGS_ATTRIBUTES} = 0 ]; then
-  # Ensure settings.json have non zero attributes (actual for Synology NAS)
-  chmod 640 ${SETTINGS_PATH} && echo "INFO: Attributes of setting.json changed to 640"
-fi
-
 echo "sed'ing True to true"
 sed -i 's/True/true/g' ${TRANSMISSION_HOME}/settings.json
 

--- a/transmission/userSetup.sh
+++ b/transmission/userSetup.sh
@@ -16,6 +16,14 @@ if [ -n "$PUID" ] && [ ! "$(id -u root)" -eq "$PUID" ]; then
         ${TRANSMISSION_DOWNLOAD_DIR} \
         ${TRANSMISSION_INCOMPLETE_DIR} \
         ${TRANSMISSION_WATCH_DIR}
+        
+    echo "Setting permission for files (644) and directories (755)"
+    chmod -R go=rX,u=rwX \
+        /config \
+        ${TRANSMISSION_HOME} \
+        ${TRANSMISSION_DOWNLOAD_DIR} \
+        ${TRANSMISSION_INCOMPLETE_DIR} \
+        ${TRANSMISSION_WATCH_DIR}        
 fi
 
 echo "


### PR DESCRIPTION
By default in Synology NAS the user Root creates files with the permissions "---------" (0).
Other users can't access to file after change file owner.
I add `chmod 640` after file creates and before `chown `command if attributes = 0.

```
echo "Check transmission settings.json file attributes"
SETTINGS_PATH=${TRANSMISSION_HOME}/settings.json
SETTINGS_ATTRIBUTES=$(stat -c %a ${SETTINGS_PATH})
if [ ${SETTINGS_ATTRIBUTES} = 0 ]; then
  # Ensure settings.json have non zero attributes (actual for Synology NAS)
  chmod 640 ${SETTINGS_PATH} && echo "INFO: Attributes of setting.json changed to 640"
fi
```

P.S. This is my first pull request.

Fix #423