### PR TITLE
Add missing bash dependency in Alpine image

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -6,7 +6,7 @@ VOLUME /config
 
 ENV DOCKERIZE_VERSION=v0.6.0
 RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
-    && apk --no-cache add dumb-init ip6tables ufw@testing openvpn shadow transmission-daemon \
+    && apk --no-cache add ip6tables ufw@testing openvpn shadow transmission-daemon \
     && echo "Install dockerize $DOCKERIZE_VERSION" \
     && wget -qO- https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz | tar xz -C /usr/bin \
     && mkdir -p /opt/transmission-ui/combustion-release /opt/transmission-ui/kettu \
@@ -108,4 +108,4 @@ ENV OPENVPN_USERNAME=**None** \
 
 # Expose port and run
 EXPOSE 9091
-CMD ["dumb-init", "/etc/openvpn/start.sh"]
+CMD ["sh", "/etc/openvpn/start.sh"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -6,7 +6,7 @@ VOLUME /config
 
 ENV DOCKERIZE_VERSION=v0.6.0
 RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
-    && apk --no-cache add ip6tables ufw@testing openvpn shadow transmission-daemon \
+    && apk --no-cache add bash dumb-init ip6tables ufw@testing openvpn shadow transmission-daemon \
     && echo "Install dockerize $DOCKERIZE_VERSION" \
     && wget -qO- https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz | tar xz -C /usr/bin \
     && mkdir -p /opt/transmission-ui/combustion-release /opt/transmission-ui/kettu \
@@ -108,4 +108,4 @@ ENV OPENVPN_USERNAME=**None** \
 
 # Expose port and run
 EXPOSE 9091
-CMD ["sh", "/etc/openvpn/start.sh"]
+CMD ["dumb-init", "/etc/openvpn/start.sh"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -9,11 +9,12 @@ RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/ap
     && apk --no-cache add bash dumb-init ip6tables ufw@testing openvpn shadow transmission-daemon \
     && echo "Install dockerize $DOCKERIZE_VERSION" \
     && wget -qO- https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz | tar xz -C /usr/bin \
-    && mkdir -p /opt/transmission-ui/combustion-release /opt/transmission-ui/kettu \
+    && mkdir -p /opt/transmission-ui \
     && echo "Install Combustion" \
     && wget -qO- https://github.com/Secretmapper/combustion/archive/release.tar.gz | tar xz -C /opt/transmission-ui \
     && echo "Install kettu" \
-    && wget -qO- https://github.com/endor/kettu/archive/master.tar.gz | tar xz -C /opt/transmission-ui/kettu \
+    && wget -qO- https://github.com/endor/kettu/archive/master.tar.gz | tar xz -C /opt/transmission-ui \
+    && mv /opt/transmission-ui/kettu-master /opt/transmission-ui/kettu \
     && rm -rf /tmp/* /var/tmp/* \
     && groupmod -g 1000 users \
     && useradd -u 911 -U -d /config -s /bin/false abc \


### PR DESCRIPTION
The "bash" environment was absent from the Alpine image, making "dumb-init" unable to start the main script "start.sh"

Also, kettu was not installed in the proper directory