### PR TITLE
Add support for multiple servers in OPENVPN_CONFIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ If you provide a list, a file will be randomly chosen in the list, this is usefu
 ```
 -e "OPENVPN_CONFIG=ipvanish-AT-Vienna-vie-c02 ipvanish-FR-Paris-par-a01 ipvanish-DE-Frankfurt-fra-a01"
 ```
+If you provide a list and the selected server goes down, after the value of ping-timeout the container will be restarted and a server will be randomly chosen, note that the faulty server can be chosen again, if this should occur, the container will be restarted again until a working server is selected.  
+
+To make sure this work in all cases, you should add ```--pull-filter ignore ping``` to your OPENVPN_OPTS variable.  
 
 As you can see, the container also expects a data volume to be mounted.
 This is where Transmission will store your downloads, incomplete downloads and look for a watch directory for new .torrent files.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Find available OpenVPN configurations by looking in the openvpn folder of the Gi
 -e "OPENVPN_CONFIG=ipvanish-AT-Vienna-vie-c02"
 ```
 
+You can also provide a list of openvpn configuration filenames separated by a space.  
+If you provide a list, a file will be randomly chosen in the list, this is useful for redundancy setups. For example:
+```
+-e "OPENVPN_CONFIG=ipvanish-AT-Vienna-vie-c02 ipvanish-FR-Paris-par-a01 ipvanish-DE-Frankfurt-fra-a01"
+```
+
 As you can see, the container also expects a data volume to be mounted.
 This is where Transmission will store your downloads, incomplete downloads and look for a watch directory for new .torrent files.
 By default a folder named transmission-home will also be created under /data, this is where Transmission stores its state.

--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -11,6 +11,15 @@ echo "Using OpenVPN provider: $OPENVPN_PROVIDER"
 
 if [ ! -z "$OPENVPN_CONFIG" ]
 then
+	n=$(echo "$OPENVPN_CONFIG" | wc -w)
+	if [ $n -gt 1 ]
+	then
+        	rnd=$((RANDOM%n+1))
+        	srv=$(echo "$OPENVPN_CONFIG" | awk -vrnd=$rnd '{print $rnd}')
+        	echo "$n servers found in OPENVPN_CONFIG, $srv chosen randomly"
+        	OPENVPN_CONFIG=$srv
+	fi
+
 	if [ -f $vpn_provider_configs/"${OPENVPN_CONFIG}".ovpn ]
   	then
 		echo "Starting OpenVPN using config ${OPENVPN_CONFIG}.ovpn"


### PR DESCRIPTION
This PR is for issue #366 

it adds support for multiple servers in OPENVPN_CONFIG
If a list of files is provided in OPENVPN_CONFIG, a file in the list is chosen randomly