### PR TITLE
Use same rpi-raspbian:stretch image for proxy

### DIFF
--- a/proxy/Dockerfile.armhf
+++ b/proxy/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM resin/rpi-raspbian:jessie
+FROM resin/rpi-raspbian:stretch
 
 RUN apt-get update \
       && apt-get install -y \


### PR DESCRIPTION
Use the same resin/rpi-raspbian:stretch image for proxy to not have to download another image and save space.