### PR TITLE
Fix transmission-rss dockerfile for arm

### DIFF
--- a/plugins/rss/Dockerfile.armhf
+++ b/plugins/rss/Dockerfile.armhf
@@ -1,12 +1,12 @@
-FROM resin/rpi-raspbian:jessie
+FROM resin/rpi-raspbian:stretch
 MAINTAINER Kristian Haugene
 
 # Update packages and install software
 RUN apt-get update \
     && apt-get -y upgrade \
-    && apt-get -y install curl gcc make ruby2.3-dev \
+    && apt-get -y install curl gcc make ruby2.3-dev libc6-dev \
     && gem install transmission-rss \
-    && curl -L https://github.com/jwilder/dockerize/releases/download/v0.2.0/dockerize-linux-armhf-v0.2.0.tar.gz | tar -C /usr/local/bin -xzv \
+    && curl -L https://github.com/jwilder/dockerize/releases/download/v0.2.0/dockerize-linux-armhf-v0.2.0.tar.gz | tar -C /usr/local/bin -xzv
 
 ADD . /etc/transmission-rss
 


### PR DESCRIPTION
Currently the dockerfile of arm didn't work because:

* Ruby max version for jessie is 2.1
* This image needed to install the libc6-dev package
* There was a typo

All of them are fixed now