### PR TITLE
Pass on arguments to pre and post start/stop hooks

### DIFF
--- a/transmission/start.sh
+++ b/transmission/start.sh
@@ -17,7 +17,7 @@ fi
 if [ -x /scripts/transmission-pre-start.sh ]
 then
    echo "Executing /scripts/transmission-pre-start.sh"
-   /scripts/transmission-pre-start.sh
+   /scripts/transmission-pre-start.sh "$*"
    echo "/scripts/transmission-pre-start.sh returned $?"
 fi
 
@@ -75,7 +75,7 @@ fi
 if [ -x /scripts/transmission-post-start.sh ]
 then
    echo "Executing /scripts/transmission-post-start.sh"
-   /scripts/transmission-post-start.sh
+   /scripts/transmission-post-start.sh "$*"
    echo "/scripts/transmission-post-start.sh returned $?"
 fi
 

--- a/transmission/stop.sh
+++ b/transmission/stop.sh
@@ -4,7 +4,7 @@
 if [ -x /scripts/transmission-pre-stop.sh ]
 then
    echo "Executing /scripts/transmission-pre-stop.sh"
-   /scripts/transmission-pre-stop.sh
+   /scripts/transmission-pre-stop.sh "$*"
    echo "/scripts/transmission-pre-stop.sh returned $?"
 fi
 
@@ -14,6 +14,6 @@ kill $(pidof transmission-daemon)
 if [ -x /scripts/transmission-post-stop.sh ]
 then
    echo "Executing /scripts/transmission-post-stop.sh"
-   /scripts/transmission-post-stop.sh
+   /scripts/transmission-post-stop.sh "$*"
    echo "/scripts/transmission-post-stop.sh returned $?"
 fi


### PR DESCRIPTION
The *start.sh* and *stop.sh* scripts receive a set of arguments from *openvpn* when invoked from *tunnelUp.sh* and *tunnelDown.sh*. They are:

 * `$1`: network interface for the VPN (e.g. `tun0`)
 * `$2`: interface MTU (e.g. `1500`)
 * `$3`: link MTU (e.g. `1570`)
 * `$4`: local IP (e.g. `10.47.10.6`)
 * `$5`: remote IP if TUN (e.g. `10.47.10.5`), network mask if TAP
 * `$6`: "init" or "restart"

This commit makes these arguments available in *transmission-pre-start.sh*, *transmission-post-start.sh*, *transmission-pre-stop.sh* and *transmission-post-stop.sh* for those users who might need them.