### PR TITLE
Create mullvad_us-il_udp53_ipv4.ovpn

### DIFF
--- a/openvpn/mullvad/mullvad_us-il_udp53_ipv4.ovpn
+++ b/openvpn/mullvad/mullvad_us-il_udp53_ipv4.ovpn
@@ -1,0 +1,33 @@
+client
+dev tun
+proto udp
+remote us-il.mullvad.net 53
+cipher AES-256-CBC
+resolv-retry infinite
+nobind
+persist-key
+persist-tun
+comp-lzo
+verb 3
+remote-cert-tls server
+ping 10
+ping-restart 60
+
+
+
+auth-user-pass /config/openvpn-credentials.txt
+ca /etc/openvpn/mullvad/mullvad_ca.crt
+crl-verify /etc/openvpn/mullvad/mullvad_crl.pem
+
+
+
+tun-ipv4
+script-security 2
+
+
+
+
+
+
+
+tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA:TLS-DHE-RSA-WITH-CAMELLIA-256-CBC-SHA:TLS-DHE-RSA-WITH-AES-128-CBC-SHA:TLS-DHE-RSA-WITH-SEED-CBC-SHA:TLS-DHE-RSA-WITH-CAMELLIA-128-CBC-SHA


### PR DESCRIPTION
Mullvad tunneling over IPv4 vs IPv6 for OMV bridge/older docker containers that don't support IPv6.