### PR TITLE
Update Dockerfile.alpine

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.8
 # MAINTAINER Kristian Haugene
 
 VOLUME /data
@@ -6,7 +6,7 @@ VOLUME /config
 
 ENV DOCKERIZE_VERSION=v0.6.0
 RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
-    && apk --no-cache add bash dumb-init ip6tables ufw@testing openvpn shadow transmission-daemon \
+    && apk --no-cache add bash dumb-init ip6tables ufw@testing openvpn shadow transmission-daemon curl \
     && echo "Install dockerize $DOCKERIZE_VERSION" \
     && wget -qO- https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz | tar xz -C /usr/bin \
     && mkdir -p /opt/transmission-ui \


### PR DESCRIPTION
Could bump the Alpine version to 3.8 now that it's stable? :) In theory it'll pull the latest Transmission-daemon 2.94 too :D

Also, `curl` attempts to run as part of the port forward script for a PIA VPN connection... But we don't install curl :P