### PR TITLE
Fix broken Nord VPN

### DIFF
--- a/openvpn/nordvpn/default.ovpn
+++ b/openvpn/nordvpn/default.ovpn
@@ -1,1 +1,1 @@
-nl8.nordvpn.com.tcp.ovpn
+nl180.nordvpn.com.tcp.ovpn


### PR DESCRIPTION
In commit 17768dca5b85eb922184025fa935677f602d5539, the file that the default conf that Nord VPN was pointing to was removed, so the container will no longer start (errors out saying it can't find the file):

```
Options error: In [CMD-LINE]:1: Error opening configuration file: /etc/openvpn/nordvpn/default
```

**Note:** I don't know if it matters what the default was... I just picked `nl180.nordvpn.com.tcp.ovpn` at random, you can change it if it really matter.

What's weird, is even if I override the config it should use with `OPENVPN_CONFIG`, it still tries to access this file and won't start. For now, I'm sticking to `2.0` to be able to get it to work.