### PR TITLE
Fix arg passing to start/stop script hooks

### DIFF
--- a/transmission/start.sh
+++ b/transmission/start.sh
@@ -17,7 +17,7 @@ fi
 if [ -x /scripts/transmission-pre-start.sh ]
 then
    echo "Executing /scripts/transmission-pre-start.sh"
-   /scripts/transmission-pre-start.sh "$*"
+   /scripts/transmission-pre-start.sh "$@"
    echo "/scripts/transmission-pre-start.sh returned $?"
 fi
 
@@ -79,7 +79,7 @@ fi
 if [ -x /scripts/transmission-post-start.sh ]
 then
    echo "Executing /scripts/transmission-post-start.sh"
-   /scripts/transmission-post-start.sh "$*"
+   /scripts/transmission-post-start.sh "$@"
    echo "/scripts/transmission-post-start.sh returned $?"
 fi
 

--- a/transmission/stop.sh
+++ b/transmission/stop.sh
@@ -4,7 +4,7 @@
 if [ -x /scripts/transmission-pre-stop.sh ]
 then
    echo "Executing /scripts/transmission-pre-stop.sh"
-   /scripts/transmission-pre-stop.sh "$*"
+   /scripts/transmission-pre-stop.sh "$@"
    echo "/scripts/transmission-pre-stop.sh returned $?"
 fi
 
@@ -14,6 +14,6 @@ kill $(pidof transmission-daemon)
 if [ -x /scripts/transmission-post-stop.sh ]
 then
    echo "Executing /scripts/transmission-post-stop.sh"
-   /scripts/transmission-post-stop.sh "$*"
+   /scripts/transmission-post-stop.sh "$@"
    echo "/scripts/transmission-post-stop.sh returned $?"
 fi


### PR DESCRIPTION
When using `"$*"` all arguments ended up as `$1` in the hook scripts, i.e. `$2` and forward they were all blank. This fixes the code so it works as originally intended (see #547).