### PR TITLE
Fix unpriviligied user to use tun device under docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ if ( [ ! -c /dev/net/tun ] ); then
 		mkdir -m 755 /dev/net
 	fi
 	mknod /dev/net/tun c 10 200
+	chmod 0755 /dev/net/tun
 fi
 
 # Load the tun module if not already loaded


### PR DESCRIPTION
I've added a chmod to tun device to allow unprivileged docker containers to use tun device and send traffic through the vpn.
Related to this issue: https://github.com/haugene/docker-transmission-openvpn/issues/41