### PR TITLE
Fix for ARM based devices (like Raspberry Pi)

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,8 +1,6 @@
 FROM resin/rpi-raspbian:stretch
 MAINTAINER Kristian Haugene
 
-RUN [ "cross-build-start" ]
-
 VOLUME /data
 VOLUME /config
 
@@ -129,5 +127,3 @@ ENV OPENVPN_USERNAME=**None** \
 # Expose port and run
 EXPOSE 9091
 CMD ["dumb-init", "/etc/openvpn/start.sh"]
-
-RUN [ "cross-build-end" ]

--- a/plugins/rss/Dockerfile.armhf
+++ b/plugins/rss/Dockerfile.armhf
@@ -1,8 +1,6 @@
 FROM resin/rpi-raspbian:stretch
 MAINTAINER Kristian Haugene
 
-RUN [ "cross-build-start" ]
-
 # Update packages and install software
 RUN apt-get update \
     && apt-get -y upgrade \
@@ -16,5 +14,3 @@ ENV TRANSMISSION_DOWNLOAD_DIR=/data/completed \
     RSS_URL=**None**
 
 CMD ["/etc/transmission-rss/start.sh"]
-
-RUN [ "cross-build-end" ]

--- a/proxy/Dockerfile.armhf
+++ b/proxy/Dockerfile.armhf
@@ -1,7 +1,5 @@
 FROM resin/rpi-raspbian:stretch
 
-RUN [ "cross-build-start" ]
-
 RUN apt-get update \
       && apt-get install -y \
         ca-certificates \
@@ -16,5 +14,3 @@ EXPOSE 8080
 COPY nginx.conf /etc/nginx/nginx.conf
 
 CMD ["nginx", "-g", "daemon off;"]
-
-RUN [ "cross-build-end" ]


### PR DESCRIPTION
Removed RUN [ "cross-build-start" ] & RUN [ "cross-build-end" ] from all .armhf files in order to work with ARM based devices