### PR TITLE
Adds pre-start for openvpn

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Once /scripts is mounted you'll need to write your custom code in the following 
 
 | Script | Function |
 |----------|----------|
+|/scripts/openvpn-pre-start.sh | This shell script will be executed before openvpn start |
 |/scripts/transmission-pre-start.sh | This shell script will be executed before transmission start |
 |/scripts/transmission-post-start.sh | This shell script will be executed after transmission start |
 |/scripts/transmission-pre-stop.sh | This shell script will be executed before transmission stop |

--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -13,6 +13,14 @@ fi
 
 echo "Using OpenVPN provider: ${OPENVPN_PROVIDER}"
 
+# If openvpn-pre-start.sh exists, run it
+if [ -x /scripts/openvpn-pre-start.sh ]
+then
+   echo "Executing /scripts/openvpn-pre-start.sh"
+   /scripts/openvpn-pre-start.sh "$@"
+   echo "/scripts/openvpn-pre-start.sh returned $?"
+fi
+
 if [[ "$OPENVPN_PROVIDER" = "NORDVPN" ]]
 then
     if [[ -z "$OPENVPN_CONFIG" ]]


### PR DESCRIPTION
I run this image on Kubernetes and I would like to create a tun device inside the container on startup, like this:

```bash
#!/bin/bash
mkdir -p /dev/net
mknod /dev/net/tun c 10 200
chmod 600 /dev/net/tun
```

Now I override the command of the container but it would be nice if this can be handled as the transmission scripts, like this:
```yaml
command: ["/bin/bash"]
args: ["-c", "/scripts/openvpn-pre-start.sh && dumb-init /etc/openvpn/start.sh"]  
```
I only added the pre-start because that one seems the most relevant to me but I can add the post-start, pre-stop etc. if necessary.