### PR TITLE
Added a health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && groupmod -g 1000 users \
     && useradd -u 911 -U -d /config -s /bin/false abc \
-    && usermod -G users abc \
+    && usermod -G users abc
 
 ADD openvpn/ /etc/openvpn/
 ADD transmission/ /etc/transmission/

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,14 @@ RUN apt-get update \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && groupmod -g 1000 users \
     && useradd -u 911 -U -d /config -s /bin/false abc \
-    && usermod -G users abc
+    && usermod -G users abc \
 
 ADD openvpn/ /etc/openvpn/
 ADD transmission/ /etc/transmission/
 ADD tinyproxy /opt/tinyproxy/
+ADD scripts /etc/scripts/
+
+RUN chmod a+x /etc/scripts/healthcheck.sh
 
 ENV OPENVPN_USERNAME=**None** \
     OPENVPN_PASSWORD=**None** \
@@ -129,7 +132,10 @@ ENV OPENVPN_USERNAME=**None** \
     TRANSMISSION_WEB_HOME= \
     DROP_DEFAULT_ROUTE= \
     WEBPROXY_ENABLED=false \
-    WEBPROXY_PORT=8888
+    WEBPROXY_PORT=8888 \
+    HEALTH_CHECK_HOST=google.com
+
+HEALTHCHECK --interval=5m CMD /etc/scripts/healthcheck.sh
 
 # Expose port and run
 EXPOSE 9091

--- a/README.md
+++ b/README.md
@@ -166,6 +166,14 @@ If TRANSMISSION_PEER_PORT_RANDOM_ON_START is enabled then it allows traffic to t
 |`UFW_EXTRA_PORTS` | Allows the comma separated list of ports through the firewall. Respects UFW_ALLOW_GW_NET. | `UFW_EXTRA_PORTS=9910,23561,443`|
 |`UFW_DISABLE_IPTABLES_REJECT` | Prevents the use of `REJECT` in the `iptables` rules, for hosts without the `ipt_REJECT` module (such as the Synology NAS). | `UFW_DISABLE_IPTABLES_REJECT=true`|
 
+### Health check option
+
+Because your VPN connection can sometimes fail, Docker will run a health check on this container every 5 minutes to see if the container is still connected to the internet. By default, this check is done by pinging google.com once. You change the host that is pinged.
+
+| Variable | Function | Example |
+|----------|----------|-------|
+| `HEALTH_CHECK_HOST` | this host is pinged to check if the network connection still works | `google.com` |
+
 ### Permission configuration options
 By default the startup script applies a default set of permissions and ownership on the transmission download, watch and incomplete directories. The GLOBAL_APPLY_PERMISSIONS directive can be used to disable this functionality.
 

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Ping uses both exit codes 1 and 2. Exit code 2 cannot be used for docker health checks,
+# therefore we use this script to catch error code 2
+HOST=$HEALTH_CHECK_HOST
+
+if [ -z "$HOST" ]
+then
+    echo "Host  not set! Set env 'HEATH_CHECK_HOST'. For now, using default google.com"
+    HOST="google.com"
+fi
+
+ping -c 1 $HOST
+STATUS=$?
+if [ $STATUS -ne 0 ]
+then
+    echo "Network is down"
+    exit 1
+fi
+
+echo "Network is up"
+exit 0
+


### PR DESCRIPTION
Sometimes transmission is unable to connect to the internet because the VPN connection shut down. The container then just sits there not doing anything, without it being noticed. A simple container restart fixes this of course, but the main problem is it going unnoticed.

Therefore I added a docker health check. It simply pings to see if the network is still up. I made a script instead of directly calling ping, because the ping command uses exit code 2 in some circumstances, which you shouldn't do according to Docker documentation. The script simply catches the ping exit code and returns either 1 or 0, to make the exit code up to spec with docker guidelines.
This also makes it easier to change or extend the way the health check is done, if need be.

The default host is google.com, this can be changed in the ENV settings. I added that new ENV variable to the readme.md.