### PR TITLE
Create new CREATE_TUN_DEVICE variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ If you provide a list, a file will be randomly chosen in the list, this is usefu
 ```
 -e "OPENVPN_CONFIG=ipvanish-AT-Vienna-vie-c02,ipvanish-FR-Paris-par-a01,ipvanish-DE-Frankfurt-fra-a01"
 ```
-If you provide a list and the selected server goes down, after the value of ping-timeout the container will be restarted and a server will be randomly chosen, note that the faulty server can be chosen again, if this should occur, the container will be restarted again until a working server is selected.  
+If you provide a list and the selected server goes down, after the value of ping-timeout the container will be restarted and a server will be randomly chosen, note that the faulty server can be chosen again, if this should occur, the container will be restarted again until a working server is selected.
 
-To make sure this work in all cases, you should add ```--pull-filter ignore ping``` to your OPENVPN_OPTS variable.  
+To make sure this work in all cases, you should add ```--pull-filter ignore ping``` to your OPENVPN_OPTS variable.
 
 As you can see, the container also expects a data volume to be mounted.
 This is where Transmission will store your downloads, incomplete downloads and look for a watch directory for new .torrent files.
@@ -153,6 +153,7 @@ This is a list of providers that are bundled within the image. Feel free to crea
 |`OPENVPN_CONFIG` | Sets the OpenVPN endpoint to connect to. | `OPENVPN_CONFIG=UK Southampton`|
 |`OPENVPN_OPTS` | Will be passed to OpenVPN on startup | See [OpenVPN doc](https://openvpn.net/index.php/open-source/documentation/manuals/65-openvpn-20x-manpage.html) |
 |`LOCAL_NETWORK` | Sets the local network that should have access. Accepts comma separated list. | `LOCAL_NETWORK=192.168.0.0/24`|
+|`CREATE_TUN_DEVICE` | Creates /dev/net/tun device inside the container, mitigates the need mount the device from the host | `CREATE_TUN_DEVICE=true`|
 
 ### Firewall configuration options
 When enabled, the firewall blocks everything except traffic to the peer port and traffic to the rpc port from the LOCAL_NETWORK and the internal docker gateway.
@@ -229,7 +230,7 @@ You may set the following parameters to customize the user id that runs transmis
 
 ### Dropping default route from iptables (advanced)
 
-Some VPNs do not override the default route, but rather set other routes with a lower metric.  
+Some VPNs do not override the default route, but rather set other routes with a lower metric.
 This might lead to the default route (your untunneled connection) to be used.
 
 To drop the default route set the environment variable `DROP_DEFAULT_ROUTE` to `true`.

--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -2,6 +2,13 @@
 VPN_PROVIDER="${OPENVPN_PROVIDER,,}"
 VPN_PROVIDER_CONFIGS="/etc/openvpn/${VPN_PROVIDER}"
 
+# If create_tun_device is set, create /dev/net/tun
+if [[ "${CREATE_TUN_DEVICE,,}" == "true" ]]; then
+  mkdir -p /dev/net
+  mknod /dev/net/tun c 10 200
+  chmod 0666 /dev/net/tun
+fi
+
 if [[ "${OPENVPN_PROVIDER}" == "**None**" ]] || [[ -z "${OPENVPN_PROVIDER-}" ]]; then
   echo "OpenVPN provider not set. Exiting."
   exit 1


### PR DESCRIPTION
As stated in #697 an option to enable creation of the /dev/net/tun device inside the container. This should mitigate the need to pass the device from the host to the container.
I create the device as the Linux kernel documentation states [here](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/networking/tuntap.txt?id=HEAD#n36).
This also enables the container to be used on Kubernetes, the `--device` parameter isn't available (only block and character devices).

I purposefully haven't written that much documentation because I don't know how to proceed. If this works like it should on NAS devices then most of that documentation can be deleted. If this totally mitigates the purpose of attaching a device the whole readme needs cleaning up.

In short please test this new approach! I build and pushed the latest and latest-alpine to Docker Hub:
https://hub.docker.com/r/lansible/transmission-openvpn/tags

(also removed trailing spaces from the readme, couldn't resist ;))