### PR TITLE
Replace resin with balenalib since the armhf image has been moved

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM resin/rpi-raspbian:stretch
+FROM balenalib/rpi-raspbian:stretch
 MAINTAINER Kristian Haugene
 
 VOLUME /data


### PR DESCRIPTION
Fixes #705 and #721 

The image just seem to have moved namespaces so just a rename. I am not able to test this image @chilicheech might?