### PR TITLE
modifying config to match Torguard config generator

### DIFF
--- a/openvpn/torguard/Denmark.ovpn
+++ b/openvpn/torguard/Denmark.ovpn
@@ -1,30 +1,39 @@
 client
 dev tun
-proto tcp
-remote den.torguardvpnaccess.com 995
+proto udp
+remote den.torguardvpnaccess.com 1912
+remote-cert-tls server
+auth SHA256
+key-direction 1
+setenv CLIENT_CERT 0
+<tls-auth>
+-----BEGIN OpenVPN Static key V1-----
+770e8de5fc56e0248cc7b5aab56be80d
+0e19cbf003c1b3ed68efbaf08613c3a1
+a019dac6a4b84f13a6198f73229ffc21
+fa512394e288f82aa2cf0180f01fb3eb
+1a71e00a077a20f6d7a83633f5b4f47f
+27e30617eaf8485dd8c722a8606d56b3
+c183f65da5d3c9001a8cbdb96c793d93
+6251098b24fe52a6dd2472e98cfccbc4
+66e63520d63ade7a0eacc36208c3142a
+1068236a52142fbb7b3ed83d785e12a2
+8261bccfb3bcb62a8d2f6d18f5df5f36
+52e59c5627d8d9c8f7877c4d7b08e19a
+5c363556ba68d392be78b75152dd55ba
+0f74d45089e84f77f4492d886524ea6c
+82b9f4dd83d46528d4f5c3b51cfeaf28
+38d938bd0597c426b0e440434f2c451f
+-----END OpenVPN Static key V1-----
+</tls-auth>
 resolv-retry infinite
 nobind
-persist-key
-persist-tun
-tun-mtu 1500
-tun-mtu-extra 32
-mssfix 1450
-ca /etc/openvpn/torguard/ca.crt
-remote-cert-tls server
+tls-version-min 1.2
+cipher AES-128-CBC
 auth-user-pass /config/openvpn-credentials.txt
-comp-lzo
-verb 3
-reneg-sec 0
-fast-io
-
-# Uncomment these directives if you have speed issues
-;sndbuf 393216
-;rcvbuf 393216
-;push "sndbuf 393216"
-;push "rcvbuf 393216"
-
-cipher AES-256-CBC
-
+compress
+ncp-disable
+tun-mtu-extra 32
 <ca>
 -----BEGIN CERTIFICATE-----
 MIIEwTCCA6mgAwIBAgIJAKROjebUHo0gMA0GCSqGSIb3DQEBBQUAMIGbMQswCQYD


### PR DESCRIPTION
**Process:**
Generated config in Torguard client area web UI. This is the exact result file, only with `auth-user-pass` changed to `auth-user-pass /config/openvpn-credentials.txt`

**Status:**
Tested and works.

**Comments:**
cipher AES-256-CBC no longer supported it seems (I tried that), only AES-128-CBC.

Tried running `./adjustConfigs.sh torguard` but it spits out lines like `sed: 1: "torguard/Austria.ovpn": undefined label 'orguard/Austria.ovpn'` for every single ovpn file.

**TODO:**
I assume the ca cert should be moved. Not sure about the format, leaving for a future kind soul.

**TODO2:**
These warnings are generated when connecting:
```
WARNING: 'link-mtu' is used inconsistently, local='link-mtu 1602', remote='link-mtu 1569'
WARNING: 'tun-mtu' is used inconsistently, local='tun-mtu 1532', remote='tun-mtu 1500'
WARNING: 'comp-lzo' is present in local config but missing in remote config, local='comp-lzo'
```
- Attempted to set both link-mtu and tun-mtu, only one can be specified.
- Attempted to specify `tun-mtu` as in former config, but it doesn't remove the warning. Overridden somewhere else?
- Not sure where comp-lzo comes from.

It works, despite warnings.