### PR TITLE
Add option to enable ipv6 in container

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ $ docker run --cap-add=NET_ADMIN -d \
               --log-driver json-file \
               --log-opt max-size=10m \
               -p 9091:9091 \
+	      --sysctl net.ipv6.conf.all.disable_ipv6=0 \
               haugene/transmission-openvpn
 ```
 


### PR DESCRIPTION
On my host (opensuse Kubic) it was necessary to explicitly enable ipv6 in the container. Otherwise the container startup would fail when the IPv6 address was set on the tun interface.