### PR TITLE
Link to the DockerEnv file

### DIFF
--- a/docs/dockerenv.md
+++ b/docs/dockerenv.md
@@ -1,5 +1,5 @@
 Another way is to use a docker env file where you can easily store all your env variables and maintain multiple configurations for different providers.
-In the GitHub repository there is a provided DockerEnv file with all the current transmission and openvpn environment variables. You can use this to create local configurations
+In the GitHub repository there is a provided [DockerEnv](https://github.com/haugene/docker-transmission-openvpn/blob/master/DockerEnv) file with all the current transmission and openvpn environment variables. You can use this to create local configurations
 by filling in the details and removing the # of the ones you want to use.
 
 Please note that if you pass in env. variables on the command line these will override the ones in the env file.


### PR DESCRIPTION
Tiny change, just updating documentation with a link to the example [DockerEnv](https://github.com/haugene/docker-transmission-openvpn/blob/master/DockerEnv) file in the repo.