### PR TITLE
Remove duplicate dot (.) in download URL for NordVPN

### DIFF
--- a/openvpn/nordvpn/updateConfigs.sh
+++ b/openvpn/nordvpn/updateConfigs.sh
@@ -85,6 +85,7 @@ select_hostname() { #TODO return multiples
 download_hostname() {
     # https://downloads.nordcdn.com/configs/files/ovpn_legacy/servers/us3349.nordvpn.com.udp1194.ovpn
     local nordvpn_cdn="https://downloads.nordcdn.com/configs/files/ovpn_legacy/servers/"
+
     if [[ "$1" == "-d" ]]; then
         nordvpn_cdn=${nordvpn_cdn}${2}
         ovpnName=default.ovpn
@@ -97,6 +98,8 @@ download_hostname() {
         nordvpn_cdn="${nordvpn_cdn}udp1194.ovpn"
     elif [[ ${NORDVPN_PROTOCOL,,} == tcp ]];then
         nordvpn_cdn="${nordvpn_cdn}tcp443.ovpn"
+    elif [[ -z ${NORDVPN_PROTOCOL,,} ]];then
+        nordvpn_cdn="${nordvpn_cdn}udp1194.ovpn"
     fi
 
     log "Downloading config: ${ovpnName}"

--- a/openvpn/nordvpn/updateConfigs.sh
+++ b/openvpn/nordvpn/updateConfigs.sh
@@ -94,9 +94,9 @@ download_hostname() {
     fi
 
     if [[ ${NORDVPN_PROTOCOL,,} == udp ]]; then
-        nordvpn_cdn="${nordvpn_cdn}.udp1194.ovpn"
+        nordvpn_cdn="${nordvpn_cdn}udp1194.ovpn"
     elif [[ ${NORDVPN_PROTOCOL,,} == tcp ]];then
-        nordvpn_cdn="${nordvpn_cdn}.tcp443.ovpn"
+        nordvpn_cdn="${nordvpn_cdn}tcp443.ovpn"
     fi
 
     log "Downloading config: ${ovpnName}"


### PR DESCRIPTION
`updateConfigs.sh` seems to be adding an extra dot (`.`) in the download URL. It's trying to download `https://downloads.nordcdn.com/configs/files/ovpn_legacy/servers/us3340.nordvpn.com..udp1194.ovpn` instead of `https://downloads.nordcdn.com/configs/files/ovpn_legacy/servers/us3340.nordvpn.com.udp1194.ovpn`.

Take this with a grain of salt, as this is the first time I'm setting up this container.

This hopefully fixes #832 