### PR TITLE
[NORDVPN] Fix setting download URL

### DIFF
--- a/openvpn/nordvpn/updateConfigs.sh
+++ b/openvpn/nordvpn/updateConfigs.sh
@@ -124,9 +124,9 @@ find . ! -name '*.sh' -type f -delete
 
 if [[ ! -z $OPENVPN_CONFIG ]] && [[ ! -z $NORDVPN_COUNTRY ]]
 then
-    default="$(select_hostname).${NORDVPN_PROTOCOL,,}"
+    default="$(select_hostname)"
 else
-    default="$(select_hostname -d).${NORDVPN_PROTOCOL,,}"
+    default="$(select_hostname -d)"
 fi
 download_hostname -d ${default}
 


### PR DESCRIPTION
I do not provide the `NORDVPN_PROTOCOL` variable in my container.

`NORDVPN_PROTOCOL` is defaulted to `"udp"` in `/openvpn/start.sh`

[L96 here](https://github.com/haugene/docker-transmission-openvpn/blob/dev/openvpn/nordvpn/updateConfigs.sh#L96) checks and provides the final portion of the .ovpn download URL which includes `.udp1194` (or `.tcp443` if `NORDVPN_PROTOCOL` was set to "tcp")

The end result in these checks and definitions causes the download URL to include an extra `.udp` in the address.
In my logs, this is the url it provides to `curl` from which is invalid:
`https://downloads.nordcdn.com/configs/files/ovpn_legacy/servers/us4436.nordvpn.com.udp.udp1194.ovpn`

It should end up being this instead:
`https://downloads.nordcdn.com/configs/files/ovpn_legacy/servers/us4436.nordvpn.com.udp1194.ovpn`

Log below:
```
Using OpenVPN provider: NORDVPN
2019-09-21 22:07:03 Checking curl installation
2019-09-21 22:07:03 Removing existing configs
2019-09-21 22:07:03 Selecting the best server...
2019-09-21 22:07:03 Searching for group: legacy_p2p
2019-09-21 22:07:03 Searching for technology: openvpn_udp
2019-09-21 22:07:03 Best server : us4436.nordvpn.com
2019-09-21 22:07:03 Downloading config: default.ovpn
2019-09-21 22:07:03 Downloading from: https://downloads.nordcdn.com/configs/files/ovpn_legacy/servers/us4436.nordvpn.com.udp.udp1194.ovpn
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current   Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   162  100   162    0     0    809      0 --:--:-- --:--:-- --:--:--   810
2019-09-21 22:07:03 Checking line endings
2019-09-21 22:07:03 Updating configs for docker-transmission-openvpn
Starting OpenVPN using config default.ovpn
Setting OPENVPN credentials...
adding route to local network 0.0.0.0 via 172.18.0.1 dev eth0
Options error: Unrecognized option or missing or extra parameter(s) in /etc/openvpn/nordvpn/default.ovpn:1: html (2.4.7)
Use --help for more information.
```