### PR TITLE
PrivateVPN server domain name change (October 2019)

### DIFF
--- a/openvpn/privatevpn/default.ovpn
+++ b/openvpn/privatevpn/default.ovpn
@@ -1,4 +1,4 @@
-remote se-sto.privatevpn.com 1194 udp
+remote se-sto.pvdata.host 1194 udp
 nobind
 dev tun
 

--- a/openvpn/privatevpn/london-uk.ovpn
+++ b/openvpn/privatevpn/london-uk.ovpn
@@ -1,4 +1,4 @@
-remote uk-lon2.privatevpn.com 1194 udp
+remote uk-lon2.pvdata.host 1194 udp
 nobind
 dev tun
 

--- a/openvpn/privatevpn/los-angeles-usa.ovpn
+++ b/openvpn/privatevpn/los-angeles-usa.ovpn
@@ -1,4 +1,4 @@
-remote us-los.privatevpn.com 1194 udp
+remote us-los.pvdata.host 1194 udp
 nobind
 dev tun
 

--- a/openvpn/privatevpn/stockholm-sweden.ovpn
+++ b/openvpn/privatevpn/stockholm-sweden.ovpn
@@ -1,4 +1,4 @@
-remote se-sto.privatevpn.com 1194 udp
+remote se-sto.pvdata.host 1194 udp
 nobind
 dev tun
 


### PR DESCRIPTION
The PrivateVPN servers changed host names from .privatevpn.com to .pvdata.host, see https://privatevpn.com/serverlist/ .

 [ Please use squash commit when merging this pull request (I edited these config files online on github.com directly, so had to commit them individually). ]