### PR TITLE
Fix for NordVPN as UDP and TCP CDN changed

### DIFF
--- a/openvpn/nordvpn/updateConfigs.sh
+++ b/openvpn/nordvpn/updateConfigs.sh
@@ -83,8 +83,17 @@ select_hostname() { #TODO return multiples
     echo ${hostname}
 }
 download_hostname() {
-    # https://downloads.nordcdn.com/configs/files/ovpn_legacy/servers/us3349.nordvpn.com.udp1194.ovpn
-    local nordvpn_cdn="https://downloads.nordcdn.com/configs/files/ovpn_legacy/servers/"
+    #udp ==> https://downloads.nordcdn.com/configs/files/ovpn_udp/servers/nl601.nordvpn.com.udp.ovpn
+    #tmp ==> https://downloads.nordcdn.com/configs/files/ovpn_tcp/servers/nl542.nordvpn.com.tcp.ovpn
+
+    local nordvpn_cdn="https://downloads.nordcdn.com/configs/files"     
+
+    if [[ ${NORDVPN_PROTOCOL,,} == udp ]]; then
+        nordvpn_cdn="${nordvpn_cdn}/ovpn_udp/servers/"
+    elif [[ ${NORDVPN_PROTOCOL,,} == tcp ]];then
+        nordvpn_cdn="${nordvpn_cdn}/ovpn_tcp/servers/"
+    fi
+
     if [[ "$1" == "-d" ]]; then
         nordvpn_cdn=${nordvpn_cdn}${2}
         ovpnName=default.ovpn
@@ -94,9 +103,9 @@ download_hostname() {
     fi
 
     if [[ ${NORDVPN_PROTOCOL,,} == udp ]]; then
-        nordvpn_cdn="${nordvpn_cdn}.udp1194.ovpn"
+        nordvpn_cdn="${nordvpn_cdn}.ovpn"
     elif [[ ${NORDVPN_PROTOCOL,,} == tcp ]];then
-        nordvpn_cdn="${nordvpn_cdn}.tcp443.ovpn"
+        nordvpn_cdn="${nordvpn_cdn}.ovpn"
     fi
 
     log "Downloading config: ${ovpnName}"

--- a/openvpn/nordvpn/updateConfigs.sh
+++ b/openvpn/nordvpn/updateConfigs.sh
@@ -102,11 +102,7 @@ download_hostname() {
         ovpnName=${1}.ovpn
     fi
 
-    if [[ ${NORDVPN_PROTOCOL,,} == udp ]]; then
-        nordvpn_cdn="${nordvpn_cdn}.ovpn"
-    elif [[ ${NORDVPN_PROTOCOL,,} == tcp ]];then
-        nordvpn_cdn="${nordvpn_cdn}.ovpn"
-    fi
+    nordvpn_cdn="${nordvpn_cdn}.ovpn"
 
     log "Downloading config: ${ovpnName}"
     log "Downloading from: ${nordvpn_cdn}"


### PR DESCRIPTION
Fixing the NordVPN CND changes. Should fix downloading from wrong URL and getting a error like.
`Options error: Unrecognized option or missing or extra parameter(s) in /etc/openvpn/nordvpn/default.ovpn:1: html (2.4.7)`
