### PR TITLE
Fix for NORDVPN default and specific vpn config download

### DIFF
--- a/openvpn/nordvpn/updateConfigs.sh
+++ b/openvpn/nordvpn/updateConfigs.sh
@@ -84,7 +84,7 @@ select_hostname() { #TODO return multiples
 }
 download_hostname() {
     #udp ==> https://downloads.nordcdn.com/configs/files/ovpn_udp/servers/nl601.nordvpn.com.udp.ovpn
-    #tmp ==> https://downloads.nordcdn.com/configs/files/ovpn_tcp/servers/nl542.nordvpn.com.tcp.ovpn
+    #tcp ==> https://downloads.nordcdn.com/configs/files/ovpn_tcp/servers/nl542.nordvpn.com.tcp.ovpn
 
     local nordvpn_cdn="https://downloads.nordcdn.com/configs/files"     
 
@@ -148,7 +148,7 @@ then
     download_hostname ${OPENVPN_CONFIG,,}
 elif [[ ! -z $NORDVPN_COUNTRY ]]
 then
-    selected="$(select_hostname).${NORDVPN_PROTOCOL,,}"
+    selected="$(select_hostname)"
     download_hostname ${selected}
 else
     selected="default"


### PR DESCRIPTION
Downloading without any NORDVPN_ environment settings or with NORDVPN_ settings should result in correctly downloading:
https://downloads.nordcdn.com/configs/files/ovpn_udp/servers/fr380.nordvpn.com.udp.ovpn
and https://downloads.nordcdn.com/configs/files/ovpn_udp/servers/nl542.nordvpn.com.udp.ovp as default (in this case with default UDP mode).