### PR TITLE
Folder permissions

### DIFF
--- a/transmission/userSetup.sh
+++ b/transmission/userSetup.sh
@@ -34,9 +34,12 @@ if [ -n "$PUID" ] && [ ! "$(id -u root)" -eq "$PUID" ]; then
             ${TRANSMISSION_WATCH_DIR}
 
 	echo "Setting permission for files (644) and directories (755)"
-        chmod -R o=rX,ug=rwX \
+        chmod -R go=rX,u=rwX \
             ${TRANSMISSION_DOWNLOAD_DIR} \
             ${TRANSMISSION_INCOMPLETE_DIR} \
+
+    echo "Setting permission for watch directory (775) and its files (664)"
+        chmod -R o=rX,ug=rwX \
             ${TRANSMISSION_WATCH_DIR}
     fi
 fi

--- a/transmission/userSetup.sh
+++ b/transmission/userSetup.sh
@@ -34,7 +34,7 @@ if [ -n "$PUID" ] && [ ! "$(id -u root)" -eq "$PUID" ]; then
             ${TRANSMISSION_WATCH_DIR}
 
 	echo "Setting permission for files (644) and directories (755)"
-        chmod -R go=rX,u=rwX \
+        chmod -R o=rX,ug=rwX \
             ${TRANSMISSION_DOWNLOAD_DIR} \
             ${TRANSMISSION_INCOMPLETE_DIR} \
             ${TRANSMISSION_WATCH_DIR}


### PR DESCRIPTION
Group write access for the watch folder is really a necessity in a multi-user setting.