### PR TITLE
Add support for ElasticTunnel VPN provider

### DIFF
--- a/openvpn/elastictunnel/canada_toronto.ovpn
+++ b/openvpn/elastictunnel/canada_toronto.ovpn
@@ -1,0 +1,321 @@
+##############################################
+# Sample client-side OpenVPN 2.0 config file #
+# for connecting to multi-client server.     #
+#                                            #
+# This configuration can be used by multiple #
+# clients, however each client should have   #
+# its own cert and key files.                #
+#                                            #
+# On Windows, you might want to rename this  #
+# file so it has a .ovpn extension           #
+##############################################
+
+# Specify that we are a client and that we
+# will be pulling certain config file directives
+# from the server.
+client
+
+# Use the same setting as you are using on
+# the server.
+# On most systems, the VPN will not function
+# unless you partially or fully disable
+# the firewall for the TUN/TAP interface.
+;dev tap
+dev tun
+
+# Windows needs the TAP-Win32 adapter name
+# from the Network Connections panel
+# if you have more than one.  On XP SP2,
+# you may need to disable the firewall
+# for the TAP adapter.
+;dev-node MyTap
+
+# Are we connecting to a TCP or
+# UDP server?  Use the same setting as
+# on the server.
+;proto tcp
+proto tcp
+
+# The hostname/IP and port of the server.
+# You can have multiple remote entries
+# to load balance between the servers.
+remote canada_toronto1.elastictunnel.com 443
+remote canada_toronto2.elastictunnel.com 443
+remote canada_toronto3.elastictunnel.com 443
+remote canada_toronto4.elastictunnel.com 443
+
+# Choose a random host from the remote
+# list for load-balancing.  Otherwise
+# try hosts in the order specified.
+;remote-random
+
+# Keep trying indefinitely to resolve the
+# host name of the OpenVPN server.  Very useful
+# on machines which are not permanently connected
+# to the internet such as laptops.
+resolv-retry infinite
+
+# Most clients don't need to bind to
+# a specific local port number.
+nobind
+
+# Downgrade privileges after initialization (non-Windows only)
+;user nobody
+;group nogroup
+
+# Try to preserve some state across restarts.
+persist-key
+persist-tun
+
+# If you are connecting through an
+# HTTP proxy to reach the actual OpenVPN
+# server, put the proxy server/IP and
+# port number here.  See the man page
+# if your proxy server requires
+# authentication.
+;http-proxy-retry # retry on connection failures
+;http-proxy [proxy server] [proxy port #]
+
+# Wireless networks often produce a lot
+# of duplicate packets.  Set this flag
+# to silence duplicate packet warnings.
+;mute-replay-warnings
+
+# SSL/TLS parms.
+# See the server config file for more
+# description.  It's best to use
+# a separate .crt/.key file pair
+# for each client.  A single ca
+# file can be used for all clients.
+#ca ca.crt
+#cert client.crt
+#key client.key
+
+# Verify server certificate by checking that the
+# certicate has the correct key usage set.
+# This is an important precaution to protect against
+# a potential attack discussed here:
+#  http://openvpn.net/howto.html#mitm
+#
+# To use this feature, you will need to generate
+# your server certificates with the keyUsage set to
+#   digitalSignature, keyEncipherment
+# and the extendedKeyUsage to
+#   serverAuth
+# EasyRSA can do this for you.
+remote-cert-tls server
+
+# If a tls-auth key is used on the server
+# then every client must also have the key.
+#tls-auth ta.key 1
+
+# Select a cryptographic cipher.
+# If the cipher option is used on the server
+# then you must also specify it here.
+# Note that v2.4 client/server will automatically
+# negotiate AES-256-GCM in TLS mode.
+# See also the ncp-cipher option in the manpage
+cipher AES-256-CBC
+
+# Enable compression on the VPN link.
+# Don't enable this unless it is also
+# enabled in the server config file.
+#comp-lzo
+
+# Set log file verbosity.
+verb 3
+
+# Silence repeating messages
+;mute 20
+user nobody
+group nogroup
+auth SHA256
+key-direction 1
+auth-user-pass /config/openvpn-credentials.txt
+auth-nocache
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFNzCCBB+gAwIBAgIUc+CJ597hV/Yo/4lOvmLGfaQHRYwwDQYJKoZIhvcNAQEL
+BQAwgbsxCzAJBgNVBAYTAlVBMRAwDgYDVQQIEwdLaGFya2l2MRAwDgYDVQQHEwdL
+aGFya2l2MRYwFAYDVQQKEw1lbGFzdGljdHVubmVsMRowGAYDVQQLExFlbGFzdGlj
+dHVubmVsLmNvbTEZMBcGA1UEAxMQZWxhc3RpY3R1bm5lbCBDQTESMBAGA1UEKRMJ
+dnBuc2VydmVyMSUwIwYJKoZIhvcNAQkBFhZpbmZvQGVsYXN0aWN0dW5uZWwuY29t
+MB4XDTE5MTExMjEzMTM1MFoXDTI5MTEwOTEzMTM1MFowgbsxCzAJBgNVBAYTAlVB
+MRAwDgYDVQQIEwdLaGFya2l2MRAwDgYDVQQHEwdLaGFya2l2MRYwFAYDVQQKEw1l
+bGFzdGljdHVubmVsMRowGAYDVQQLExFlbGFzdGljdHVubmVsLmNvbTEZMBcGA1UE
+AxMQZWxhc3RpY3R1bm5lbCBDQTESMBAGA1UEKRMJdnBuc2VydmVyMSUwIwYJKoZI
+hvcNAQkBFhZpbmZvQGVsYXN0aWN0dW5uZWwuY29tMIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAr3wMwbUIDH/awDltPkRCDiksWZQInj+fktqiaqGO3j/9
+sYkYAZyEra8J32r6PJd+6I993DGtYBTZUOagnMbIA288ruMNdwAeL9XJu517fxzb
+PMaMp1bKbghmDMx5vSyVyOriUhevjj7fp72zQMqjfBXwBU3U8bWBeZIvYKiCUT1n
+jRn4S7iJk3r7F8ah++teqc+qUGBad0/TZ2dub2I/j9pyDCuKTj79Hpl0EvgDrczQ
+kz7asKmQJkrMDJM5tD3wyBrIg23hOHgwy2HuufZW3tG6FtVTyXC0vrUzPWgqdRrY
+AH8De7BF5/VkFevcJDMr6hcs5nfuYwXRHWJHafd16QIDAQABo4IBLzCCASswHQYD
+VR0OBBYEFBcIWxjlIrIx/hRhFgSSxPS7uPLyMIH7BgNVHSMEgfMwgfCAFBcIWxjl
+IrIx/hRhFgSSxPS7uPLyoYHBpIG+MIG7MQswCQYDVQQGEwJVQTEQMA4GA1UECBMH
+S2hhcmtpdjEQMA4GA1UEBxMHS2hhcmtpdjEWMBQGA1UEChMNZWxhc3RpY3R1bm5l
+bDEaMBgGA1UECxMRZWxhc3RpY3R1bm5lbC5jb20xGTAXBgNVBAMTEGVsYXN0aWN0
+dW5uZWwgQ0ExEjAQBgNVBCkTCXZwbnNlcnZlcjElMCMGCSqGSIb3DQEJARYWaW5m
+b0BlbGFzdGljdHVubmVsLmNvbYIUc+CJ597hV/Yo/4lOvmLGfaQHRYwwDAYDVR0T
+BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEASZBfqX7gvSqekHb5NLmzoHaZxvIu
+E8ccMfZDg0htJUh7RTIq8V/ZW1e/D2o8xvbDcio8Z6ukZdVeI789pA29iMZSsdcr
+MfkhVehZ3Niqf5geWmk1VJ680dvnFN4X16d+QB0v0XgKNQzHG9JkOiub9xhTsna0
+FlWBQqUKrQvorHvhWwrhJHV8/eB0mOutRVZ7b61c18E/fWNtzl4w+MTcDbaWl+34
+IgSXwPQVorWedcrgU0PEHQgYOb3fADoEILIqGvODtRqePCKcIoeDzFWuERc1g+tu
+iauWS+ggvMSlRS0Dwpwm/bn9wGCTpjFLcpR/Ie9ankrDompML5x6P4J9dA==
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 2 (0x2)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=UA, ST=Kharkiv, L=Kharkiv, O=elastictunnel, OU=elastictunnel.com, CN=elastictunnel CA/name=vpnserver/emailAddress=info@elastictunnel.com
+        Validity
+            Not Before: Nov 12 13:15:49 2019 GMT
+            Not After : Nov  9 13:15:49 2029 GMT
+        Subject: C=UA, ST=Kharkiv, L=Kharkiv, O=elastictunnel, OU=elastictunnel.com, CN=vpnclient/name=vpnserver/emailAddress=info@elastictunnel.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:ba:6e:eb:81:c7:14:3d:fe:28:81:2b:71:79:7e:
+                    00:d2:82:04:bd:66:1c:22:e2:dc:d0:18:5f:3a:ba:
+                    59:6d:eb:2e:43:8e:e7:62:4c:01:3f:1a:48:22:b2:
+                    13:50:e0:8e:64:f8:bf:6f:6a:59:4f:f9:98:7f:1a:
+                    e2:37:82:35:de:ac:73:65:ef:8b:b1:37:cd:3d:c1:
+                    92:c9:e8:42:20:5c:b0:1f:9a:bb:30:ca:9d:8a:85:
+                    29:d7:50:c3:29:fc:13:62:da:2d:9e:3b:c4:34:cf:
+                    bf:84:36:bc:13:01:25:97:91:00:90:ca:ab:fc:63:
+                    e9:e1:db:29:ce:28:e7:f8:ce:77:3e:e1:1f:9c:64:
+                    25:71:6c:e6:1b:e2:7f:a4:15:71:e2:ee:ad:c9:ec:
+                    43:43:d2:e4:8a:cf:e5:73:6c:7e:25:1a:a3:8a:6d:
+                    fc:a7:6a:89:72:af:af:33:d1:fe:78:e3:43:6b:33:
+                    22:f5:4e:e0:c5:c8:b4:f0:2a:82:4c:a7:03:a1:b9:
+                    ca:0a:8b:69:c9:77:55:ea:d4:0d:c7:9b:8d:c1:2c:
+                    d3:47:fe:67:9f:1f:27:f1:aa:45:1e:31:c4:bc:46:
+                    af:a0:cc:9b:37:18:3e:3e:99:4f:9c:46:7d:2c:81:
+                    de:59:72:69:19:2e:2e:8f:d0:3d:6a:f7:09:49:1e:
+                    ac:3f
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            Netscape Comment:
+                Easy-RSA Generated Certificate
+            X509v3 Subject Key Identifier:
+                69:EB:87:03:F4:E1:1B:CA:7D:F8:05:04:BB:78:20:7F:FB:E4:BE:97
+            X509v3 Authority Key Identifier:
+                keyid:17:08:5B:18:E5:22:B2:31:FE:14:61:16:04:92:C4:F4:BB:B8:F2:F2
+                DirName:/C=UA/ST=Kharkiv/L=Kharkiv/O=elastictunnel/OU=elastictunnel.com/CN=elastictunnel CA/name=vpnserver/emailAddress=info@elastictunnel.com
+                serial:73:E0:89:E7:DE:E1:57:F6:28:FF:89:4E:BE:62:C6:7D:A4:07:45:8C
+
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication
+            X509v3 Key Usage:
+                Digital Signature
+            X509v3 Subject Alternative Name:
+                DNS:vpnclient
+    Signature Algorithm: sha256WithRSAEncryption
+         13:bc:79:7d:ea:10:99:00:0f:11:65:d3:19:ce:ad:0a:5c:68:
+         c7:e3:bc:80:eb:60:6a:c9:d0:70:8f:6d:d2:34:f2:40:5e:95:
+         1a:f9:fd:b4:89:44:75:e4:54:4c:89:12:32:bc:05:81:43:22:
+         0a:93:db:f6:df:1c:ae:9c:33:54:db:a1:85:96:7c:c8:52:06:
+         02:e2:bc:c8:89:12:67:3a:2e:96:e1:20:52:ec:8b:a4:f3:0a:
+         2b:48:e4:30:3a:28:47:8a:29:5d:c4:b8:ac:24:3f:65:c8:9e:
+         a9:85:ed:03:c4:79:44:33:5b:ab:5c:92:9c:dc:eb:07:c1:9b:
+         9c:1d:61:f8:c8:e1:f1:1e:89:f7:19:d1:75:e2:ca:2f:e6:20:
+         2f:c9:1d:d4:7e:c8:4f:de:2c:ce:e3:f5:fa:c4:49:e6:f8:03:
+         5f:22:af:5e:a3:78:bb:53:cc:75:ab:37:8a:fb:41:59:a0:28:
+         bb:5f:1d:23:a9:f6:32:1d:54:63:4a:94:64:14:76:9b:6f:da:
+         0d:04:dc:9c:8c:ba:01:87:03:86:4b:c6:3a:65:b8:70:31:da:
+         6f:3c:df:c4:94:c6:18:42:d1:a1:9a:fa:99:a7:d3:de:77:0c:
+         21:0d:60:16:41:f6:59:a3:9b:b5:a9:07:9b:a1:cf:44:34:f8:
+         92:db:f0:5d
+-----BEGIN CERTIFICATE-----
+MIIFgTCCBGmgAwIBAgIBAjANBgkqhkiG9w0BAQsFADCBuzELMAkGA1UEBhMCVUEx
+EDAOBgNVBAgTB0toYXJraXYxEDAOBgNVBAcTB0toYXJraXYxFjAUBgNVBAoTDWVs
+YXN0aWN0dW5uZWwxGjAYBgNVBAsTEWVsYXN0aWN0dW5uZWwuY29tMRkwFwYDVQQD
+ExBlbGFzdGljdHVubmVsIENBMRIwEAYDVQQpEwl2cG5zZXJ2ZXIxJTAjBgkqhkiG
+9w0BCQEWFmluZm9AZWxhc3RpY3R1bm5lbC5jb20wHhcNMTkxMTEyMTMxNTQ5WhcN
+MjkxMTA5MTMxNTQ5WjCBtDELMAkGA1UEBhMCVUExEDAOBgNVBAgTB0toYXJraXYx
+EDAOBgNVBAcTB0toYXJraXYxFjAUBgNVBAoTDWVsYXN0aWN0dW5uZWwxGjAYBgNV
+BAsTEWVsYXN0aWN0dW5uZWwuY29tMRIwEAYDVQQDEwl2cG5jbGllbnQxEjAQBgNV
+BCkTCXZwbnNlcnZlcjElMCMGCSqGSIb3DQEJARYWaW5mb0BlbGFzdGljdHVubmVs
+LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALpu64HHFD3+KIEr
+cXl+ANKCBL1mHCLi3NAYXzq6WW3rLkOO52JMAT8aSCKyE1DgjmT4v29qWU/5mH8a
+4jeCNd6sc2Xvi7E3zT3BksnoQiBcsB+auzDKnYqFKddQwyn8E2LaLZ47xDTPv4Q2
+vBMBJZeRAJDKq/xj6eHbKc4o5/jOdz7hH5xkJXFs5hvif6QVceLurcnsQ0PS5IrP
+5XNsfiUao4pt/KdqiXKvrzPR/njjQ2szIvVO4MXItPAqgkynA6G5ygqLacl3VerU
+DcebjcEs00f+Z58fJ/GqRR4xxLxGr6DMmzcYPj6ZT5xGfSyB3llyaRkuLo/QPWr3
+CUkerD8CAwEAAaOCAZMwggGPMAkGA1UdEwQCMAAwLQYJYIZIAYb4QgENBCAWHkVh
+c3ktUlNBIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4EFgQUaeuHA/ThG8p9
++AUEu3ggf/vkvpcwgfsGA1UdIwSB8zCB8IAUFwhbGOUisjH+FGEWBJLE9Lu48vKh
+gcGkgb4wgbsxCzAJBgNVBAYTAlVBMRAwDgYDVQQIEwdLaGFya2l2MRAwDgYDVQQH
+EwdLaGFya2l2MRYwFAYDVQQKEw1lbGFzdGljdHVubmVsMRowGAYDVQQLExFlbGFz
+dGljdHVubmVsLmNvbTEZMBcGA1UEAxMQZWxhc3RpY3R1bm5lbCBDQTESMBAGA1UE
+KRMJdnBuc2VydmVyMSUwIwYJKoZIhvcNAQkBFhZpbmZvQGVsYXN0aWN0dW5uZWwu
+Y29tghRz4Inn3uFX9ij/iU6+YsZ9pAdFjDATBgNVHSUEDDAKBggrBgEFBQcDAjAL
+BgNVHQ8EBAMCB4AwFAYDVR0RBA0wC4IJdnBuY2xpZW50MA0GCSqGSIb3DQEBCwUA
+A4IBAQATvHl96hCZAA8RZdMZzq0KXGjH47yA62BqydBwj23SNPJAXpUa+f20iUR1
+5FRMiRIyvAWBQyIKk9v23xyunDNU26GFlnzIUgYC4rzIiRJnOi6W4SBS7Iuk8wor
+SOQwOihHiildxLisJD9lyJ6phe0DxHlEM1urXJKc3OsHwZucHWH4yOHxHon3GdF1
+4sov5iAvyR3UfshP3izO4/X6xEnm+ANfIq9eo3i7U8x1qzeK+0FZoCi7Xx0jqfYy
+HVRjSpRkFHabb9oNBNycjLoBhwOGS8Y6ZbhwMdpvPN/ElMYYQtGhmvqZp9Pedwwh
+DWAWQfZZo5u1qQeboc9ENPiS2/Bd
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQC6buuBxxQ9/iiB
+K3F5fgDSggS9Zhwi4tzQGF86ullt6y5DjudiTAE/GkgishNQ4I5k+L9vallP+Zh/
+GuI3gjXerHNl74uxN809wZLJ6EIgXLAfmrswyp2KhSnXUMMp/BNi2i2eO8Q0z7+E
+NrwTASWXkQCQyqv8Y+nh2ynOKOf4znc+4R+cZCVxbOYb4n+kFXHi7q3J7END0uSK
+z+VzbH4lGqOKbfynaolyr68z0f5440NrMyL1TuDFyLTwKoJMpwOhucoKi2nJd1Xq
+1A3Hm43BLNNH/mefHyfxqkUeMcS8Rq+gzJs3GD4+mU+cRn0sgd5ZcmkZLi6P0D1q
+9wlJHqw/AgMBAAECggEABIDPYXgcjg7Ija4t9IBNpsgLM0P3JASUztX33uRHardG
+i80025P4Z7zLx0LD4q0540h630cTVzIxM8jDdBHKGVHTC8BIgIRXiclWMVhR2JRE
+kM7c/KW4PnNO+mtx+16iXT3l4i+RYrEt8BSeYFsjvFB9UgIDO3pyWMlBbkBgsgrI
+BaFVSvDliQJ/YOGVZnYavvbUSTdxlqdhz3BDQGc6ogB/9FUcODdIpHRf1AoBZnbt
+AKoHfEnmRXfk/+uL2pg0DrIhStRIuOJdE1kZNpaxoLzDom1X+lOFpwy60Ith161b
+EjV+Ol2V8QvX/TT/T8WuVuZ/tbGSdTdX44bfkE5V6QKBgQD3ke5mEir4G89/RrhF
+zP1jq29NPUNZ3yDmb+4adk9RxCc0Bq02o7qZ/C2s4gOAY+ZnkBa32Fih0HnXg/rC
+PFSapXbjPIp3AR3Ej5tedQqDATYiXe0fOcJ+Mz9zM6O7Vnri4ZGGGH7Lg+sNVlMi
+fqbEVS3wZk/CeZzOGFN4nHKdSwKBgQDAyA8zG5PS8vYfSr2BeWCiLYor+83Qonn2
+iIPifez5uTpGdyDoFY57jaF/lZfsIte/8eh7jpZrDD7HdXpWwyxNBkHu5a7eN5kh
+K6XqZnkSmrR8+MmTfJGMYV4Q8SdIdUn7EZ2o8++YJUmqFpHBFYS53KwyKI3crUcl
+wxJT1uWYXQKBgDGQvPsgjgvIfZ2Myh3ncZ+/1fPP3SkkHBEmvbP8ldrX+8VVxN4Y
+n6Zur7JaObs9xQZc+b9rCCu1cn9shArZS1L+57ONDmfPCGevHLsnkagy2OS+i1fi
+F4duuThWUWSTZtz/rkP7qX8TdT7hVpmkY70RFLZ5tWRJNtSoWCXgpK3LAoGAbjk0
+r5UB9SfjX0rdhUy/2ppNGQ7Uw4hSUYoGVhaHytSEJEvyrZ+9opj9ELSYc3QMhXur
+4BFLoZMTxfk+ZKMdDkEYq535WKbTT+rj51yFtwRrU9Tvc/tSQMBfBzLKshwVm46b
+5UDr6cLQFobm+U3zYE1yyw7y5YzRVB7vuK3zAiUCgYANQf7424AlLJHxyV6KTykC
+q0cqLEwKzfyo4tcAEIabUSyUhx8bZ74t9ZeBA4aztr0hSXllqXPnNma+nHtPe52U
+qRqKjYJSDZ0+iBihUGhnSZO7kguIE3ZbhE+xIkdN2a8wa4GvZOP3y2RgrqopLgZ6
+Tm0qw9kd/msS9X/ZL0URmg==
+-----END PRIVATE KEY-----
+</key>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+1b1ee2134ec91c40fd0658129ae62fc8
+35b940aec925456d5b14fde10c27b694
+59441671889a4b814934644f5163ad10
+3514fabf08bfc35ee8157210c2ae95fa
+f42463b3492e4f966263512342a50201
+c9ac55058652224421a74f431564ed1f
+388e01844b124637aa89688844a3bc08
+9485a1778137d975808f14f4fa1e0dc6
+ae8d8059d80832d8e9ae8db1ba6575aa
+571a08e975f7aa674e73ddf37afbfcac
+ec4b725c86fe447b44a0849a00b914b7
+32cb411cd6f239cd59a936a099ac017d
+2c3b38e53c1ce188f3c157ca943dfdb7
+de8296711496138873da53fbcd3052fc
+3a5e584417ed052ed8c276de7bd2ebb6
+45abbb3f31ee05a8bdf52df536068f76
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/openvpn/elastictunnel/germany_frankfurt.ovpn
+++ b/openvpn/elastictunnel/germany_frankfurt.ovpn
@@ -1,0 +1,321 @@
+##############################################
+# Sample client-side OpenVPN 2.0 config file #
+# for connecting to multi-client server.     #
+#                                            #
+# This configuration can be used by multiple #
+# clients, however each client should have   #
+# its own cert and key files.                #
+#                                            #
+# On Windows, you might want to rename this  #
+# file so it has a .ovpn extension           #
+##############################################
+
+# Specify that we are a client and that we
+# will be pulling certain config file directives
+# from the server.
+client
+
+# Use the same setting as you are using on
+# the server.
+# On most systems, the VPN will not function
+# unless you partially or fully disable
+# the firewall for the TUN/TAP interface.
+;dev tap
+dev tun
+
+# Windows needs the TAP-Win32 adapter name
+# from the Network Connections panel
+# if you have more than one.  On XP SP2,
+# you may need to disable the firewall
+# for the TAP adapter.
+;dev-node MyTap
+
+# Are we connecting to a TCP or
+# UDP server?  Use the same setting as
+# on the server.
+;proto tcp
+proto tcp
+
+# The hostname/IP and port of the server.
+# You can have multiple remote entries
+# to load balance between the servers.
+remote germany_frankfurt1.elastictunnel.com 1194
+remote germany_frankfurt2.elastictunnel.com 1194
+remote germany_frankfurt3.elastictunnel.com 1194
+remote germany_frankfurt4.elastictunnel.com 1194
+
+# Choose a random host from the remote
+# list for load-balancing.  Otherwise
+# try hosts in the order specified.
+;remote-random
+
+# Keep trying indefinitely to resolve the
+# host name of the OpenVPN server.  Very useful
+# on machines which are not permanently connected
+# to the internet such as laptops.
+resolv-retry infinite
+
+# Most clients don't need to bind to
+# a specific local port number.
+nobind
+
+# Downgrade privileges after initialization (non-Windows only)
+;user nobody
+;group nogroup
+
+# Try to preserve some state across restarts.
+persist-key
+persist-tun
+
+# If you are connecting through an
+# HTTP proxy to reach the actual OpenVPN
+# server, put the proxy server/IP and
+# port number here.  See the man page
+# if your proxy server requires
+# authentication.
+;http-proxy-retry # retry on connection failures
+;http-proxy [proxy server] [proxy port #]
+
+# Wireless networks often produce a lot
+# of duplicate packets.  Set this flag
+# to silence duplicate packet warnings.
+;mute-replay-warnings
+
+# SSL/TLS parms.
+# See the server config file for more
+# description.  It's best to use
+# a separate .crt/.key file pair
+# for each client.  A single ca
+# file can be used for all clients.
+#ca ca.crt
+#cert client.crt
+#key client.key
+
+# Verify server certificate by checking that the
+# certicate has the correct key usage set.
+# This is an important precaution to protect against
+# a potential attack discussed here:
+#  http://openvpn.net/howto.html#mitm
+#
+# To use this feature, you will need to generate
+# your server certificates with the keyUsage set to
+#   digitalSignature, keyEncipherment
+# and the extendedKeyUsage to
+#   serverAuth
+# EasyRSA can do this for you.
+remote-cert-tls server
+
+# If a tls-auth key is used on the server
+# then every client must also have the key.
+#tls-auth ta.key 1
+
+# Select a cryptographic cipher.
+# If the cipher option is used on the server
+# then you must also specify it here.
+# Note that v2.4 client/server will automatically
+# negotiate AES-256-GCM in TLS mode.
+# See also the ncp-cipher option in the manpage
+cipher AES-256-CBC
+
+# Enable compression on the VPN link.
+# Don't enable this unless it is also
+# enabled in the server config file.
+#comp-lzo
+
+# Set log file verbosity.
+verb 3
+
+# Silence repeating messages
+;mute 20
+user nobody
+group nogroup
+auth SHA256
+key-direction 1
+auth-user-pass /config/openvpn-credentials.txt
+auth-nocache
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFNzCCBB+gAwIBAgIUc+CJ597hV/Yo/4lOvmLGfaQHRYwwDQYJKoZIhvcNAQEL
+BQAwgbsxCzAJBgNVBAYTAlVBMRAwDgYDVQQIEwdLaGFya2l2MRAwDgYDVQQHEwdL
+aGFya2l2MRYwFAYDVQQKEw1lbGFzdGljdHVubmVsMRowGAYDVQQLExFlbGFzdGlj
+dHVubmVsLmNvbTEZMBcGA1UEAxMQZWxhc3RpY3R1bm5lbCBDQTESMBAGA1UEKRMJ
+dnBuc2VydmVyMSUwIwYJKoZIhvcNAQkBFhZpbmZvQGVsYXN0aWN0dW5uZWwuY29t
+MB4XDTE5MTExMjEzMTM1MFoXDTI5MTEwOTEzMTM1MFowgbsxCzAJBgNVBAYTAlVB
+MRAwDgYDVQQIEwdLaGFya2l2MRAwDgYDVQQHEwdLaGFya2l2MRYwFAYDVQQKEw1l
+bGFzdGljdHVubmVsMRowGAYDVQQLExFlbGFzdGljdHVubmVsLmNvbTEZMBcGA1UE
+AxMQZWxhc3RpY3R1bm5lbCBDQTESMBAGA1UEKRMJdnBuc2VydmVyMSUwIwYJKoZI
+hvcNAQkBFhZpbmZvQGVsYXN0aWN0dW5uZWwuY29tMIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAr3wMwbUIDH/awDltPkRCDiksWZQInj+fktqiaqGO3j/9
+sYkYAZyEra8J32r6PJd+6I993DGtYBTZUOagnMbIA288ruMNdwAeL9XJu517fxzb
+PMaMp1bKbghmDMx5vSyVyOriUhevjj7fp72zQMqjfBXwBU3U8bWBeZIvYKiCUT1n
+jRn4S7iJk3r7F8ah++teqc+qUGBad0/TZ2dub2I/j9pyDCuKTj79Hpl0EvgDrczQ
+kz7asKmQJkrMDJM5tD3wyBrIg23hOHgwy2HuufZW3tG6FtVTyXC0vrUzPWgqdRrY
+AH8De7BF5/VkFevcJDMr6hcs5nfuYwXRHWJHafd16QIDAQABo4IBLzCCASswHQYD
+VR0OBBYEFBcIWxjlIrIx/hRhFgSSxPS7uPLyMIH7BgNVHSMEgfMwgfCAFBcIWxjl
+IrIx/hRhFgSSxPS7uPLyoYHBpIG+MIG7MQswCQYDVQQGEwJVQTEQMA4GA1UECBMH
+S2hhcmtpdjEQMA4GA1UEBxMHS2hhcmtpdjEWMBQGA1UEChMNZWxhc3RpY3R1bm5l
+bDEaMBgGA1UECxMRZWxhc3RpY3R1bm5lbC5jb20xGTAXBgNVBAMTEGVsYXN0aWN0
+dW5uZWwgQ0ExEjAQBgNVBCkTCXZwbnNlcnZlcjElMCMGCSqGSIb3DQEJARYWaW5m
+b0BlbGFzdGljdHVubmVsLmNvbYIUc+CJ597hV/Yo/4lOvmLGfaQHRYwwDAYDVR0T
+BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEASZBfqX7gvSqekHb5NLmzoHaZxvIu
+E8ccMfZDg0htJUh7RTIq8V/ZW1e/D2o8xvbDcio8Z6ukZdVeI789pA29iMZSsdcr
+MfkhVehZ3Niqf5geWmk1VJ680dvnFN4X16d+QB0v0XgKNQzHG9JkOiub9xhTsna0
+FlWBQqUKrQvorHvhWwrhJHV8/eB0mOutRVZ7b61c18E/fWNtzl4w+MTcDbaWl+34
+IgSXwPQVorWedcrgU0PEHQgYOb3fADoEILIqGvODtRqePCKcIoeDzFWuERc1g+tu
+iauWS+ggvMSlRS0Dwpwm/bn9wGCTpjFLcpR/Ie9ankrDompML5x6P4J9dA==
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 2 (0x2)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=UA, ST=Kharkiv, L=Kharkiv, O=elastictunnel, OU=elastictunnel.com, CN=elastictunnel CA/name=vpnserver/emailAddress=info@elastictunnel.com
+        Validity
+            Not Before: Nov 12 13:15:49 2019 GMT
+            Not After : Nov  9 13:15:49 2029 GMT
+        Subject: C=UA, ST=Kharkiv, L=Kharkiv, O=elastictunnel, OU=elastictunnel.com, CN=vpnclient/name=vpnserver/emailAddress=info@elastictunnel.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:ba:6e:eb:81:c7:14:3d:fe:28:81:2b:71:79:7e:
+                    00:d2:82:04:bd:66:1c:22:e2:dc:d0:18:5f:3a:ba:
+                    59:6d:eb:2e:43:8e:e7:62:4c:01:3f:1a:48:22:b2:
+                    13:50:e0:8e:64:f8:bf:6f:6a:59:4f:f9:98:7f:1a:
+                    e2:37:82:35:de:ac:73:65:ef:8b:b1:37:cd:3d:c1:
+                    92:c9:e8:42:20:5c:b0:1f:9a:bb:30:ca:9d:8a:85:
+                    29:d7:50:c3:29:fc:13:62:da:2d:9e:3b:c4:34:cf:
+                    bf:84:36:bc:13:01:25:97:91:00:90:ca:ab:fc:63:
+                    e9:e1:db:29:ce:28:e7:f8:ce:77:3e:e1:1f:9c:64:
+                    25:71:6c:e6:1b:e2:7f:a4:15:71:e2:ee:ad:c9:ec:
+                    43:43:d2:e4:8a:cf:e5:73:6c:7e:25:1a:a3:8a:6d:
+                    fc:a7:6a:89:72:af:af:33:d1:fe:78:e3:43:6b:33:
+                    22:f5:4e:e0:c5:c8:b4:f0:2a:82:4c:a7:03:a1:b9:
+                    ca:0a:8b:69:c9:77:55:ea:d4:0d:c7:9b:8d:c1:2c:
+                    d3:47:fe:67:9f:1f:27:f1:aa:45:1e:31:c4:bc:46:
+                    af:a0:cc:9b:37:18:3e:3e:99:4f:9c:46:7d:2c:81:
+                    de:59:72:69:19:2e:2e:8f:d0:3d:6a:f7:09:49:1e:
+                    ac:3f
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            Netscape Comment:
+                Easy-RSA Generated Certificate
+            X509v3 Subject Key Identifier:
+                69:EB:87:03:F4:E1:1B:CA:7D:F8:05:04:BB:78:20:7F:FB:E4:BE:97
+            X509v3 Authority Key Identifier:
+                keyid:17:08:5B:18:E5:22:B2:31:FE:14:61:16:04:92:C4:F4:BB:B8:F2:F2
+                DirName:/C=UA/ST=Kharkiv/L=Kharkiv/O=elastictunnel/OU=elastictunnel.com/CN=elastictunnel CA/name=vpnserver/emailAddress=info@elastictunnel.com
+                serial:73:E0:89:E7:DE:E1:57:F6:28:FF:89:4E:BE:62:C6:7D:A4:07:45:8C
+
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication
+            X509v3 Key Usage:
+                Digital Signature
+            X509v3 Subject Alternative Name:
+                DNS:vpnclient
+    Signature Algorithm: sha256WithRSAEncryption
+         13:bc:79:7d:ea:10:99:00:0f:11:65:d3:19:ce:ad:0a:5c:68:
+         c7:e3:bc:80:eb:60:6a:c9:d0:70:8f:6d:d2:34:f2:40:5e:95:
+         1a:f9:fd:b4:89:44:75:e4:54:4c:89:12:32:bc:05:81:43:22:
+         0a:93:db:f6:df:1c:ae:9c:33:54:db:a1:85:96:7c:c8:52:06:
+         02:e2:bc:c8:89:12:67:3a:2e:96:e1:20:52:ec:8b:a4:f3:0a:
+         2b:48:e4:30:3a:28:47:8a:29:5d:c4:b8:ac:24:3f:65:c8:9e:
+         a9:85:ed:03:c4:79:44:33:5b:ab:5c:92:9c:dc:eb:07:c1:9b:
+         9c:1d:61:f8:c8:e1:f1:1e:89:f7:19:d1:75:e2:ca:2f:e6:20:
+         2f:c9:1d:d4:7e:c8:4f:de:2c:ce:e3:f5:fa:c4:49:e6:f8:03:
+         5f:22:af:5e:a3:78:bb:53:cc:75:ab:37:8a:fb:41:59:a0:28:
+         bb:5f:1d:23:a9:f6:32:1d:54:63:4a:94:64:14:76:9b:6f:da:
+         0d:04:dc:9c:8c:ba:01:87:03:86:4b:c6:3a:65:b8:70:31:da:
+         6f:3c:df:c4:94:c6:18:42:d1:a1:9a:fa:99:a7:d3:de:77:0c:
+         21:0d:60:16:41:f6:59:a3:9b:b5:a9:07:9b:a1:cf:44:34:f8:
+         92:db:f0:5d
+-----BEGIN CERTIFICATE-----
+MIIFgTCCBGmgAwIBAgIBAjANBgkqhkiG9w0BAQsFADCBuzELMAkGA1UEBhMCVUEx
+EDAOBgNVBAgTB0toYXJraXYxEDAOBgNVBAcTB0toYXJraXYxFjAUBgNVBAoTDWVs
+YXN0aWN0dW5uZWwxGjAYBgNVBAsTEWVsYXN0aWN0dW5uZWwuY29tMRkwFwYDVQQD
+ExBlbGFzdGljdHVubmVsIENBMRIwEAYDVQQpEwl2cG5zZXJ2ZXIxJTAjBgkqhkiG
+9w0BCQEWFmluZm9AZWxhc3RpY3R1bm5lbC5jb20wHhcNMTkxMTEyMTMxNTQ5WhcN
+MjkxMTA5MTMxNTQ5WjCBtDELMAkGA1UEBhMCVUExEDAOBgNVBAgTB0toYXJraXYx
+EDAOBgNVBAcTB0toYXJraXYxFjAUBgNVBAoTDWVsYXN0aWN0dW5uZWwxGjAYBgNV
+BAsTEWVsYXN0aWN0dW5uZWwuY29tMRIwEAYDVQQDEwl2cG5jbGllbnQxEjAQBgNV
+BCkTCXZwbnNlcnZlcjElMCMGCSqGSIb3DQEJARYWaW5mb0BlbGFzdGljdHVubmVs
+LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALpu64HHFD3+KIEr
+cXl+ANKCBL1mHCLi3NAYXzq6WW3rLkOO52JMAT8aSCKyE1DgjmT4v29qWU/5mH8a
+4jeCNd6sc2Xvi7E3zT3BksnoQiBcsB+auzDKnYqFKddQwyn8E2LaLZ47xDTPv4Q2
+vBMBJZeRAJDKq/xj6eHbKc4o5/jOdz7hH5xkJXFs5hvif6QVceLurcnsQ0PS5IrP
+5XNsfiUao4pt/KdqiXKvrzPR/njjQ2szIvVO4MXItPAqgkynA6G5ygqLacl3VerU
+DcebjcEs00f+Z58fJ/GqRR4xxLxGr6DMmzcYPj6ZT5xGfSyB3llyaRkuLo/QPWr3
+CUkerD8CAwEAAaOCAZMwggGPMAkGA1UdEwQCMAAwLQYJYIZIAYb4QgENBCAWHkVh
+c3ktUlNBIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4EFgQUaeuHA/ThG8p9
++AUEu3ggf/vkvpcwgfsGA1UdIwSB8zCB8IAUFwhbGOUisjH+FGEWBJLE9Lu48vKh
+gcGkgb4wgbsxCzAJBgNVBAYTAlVBMRAwDgYDVQQIEwdLaGFya2l2MRAwDgYDVQQH
+EwdLaGFya2l2MRYwFAYDVQQKEw1lbGFzdGljdHVubmVsMRowGAYDVQQLExFlbGFz
+dGljdHVubmVsLmNvbTEZMBcGA1UEAxMQZWxhc3RpY3R1bm5lbCBDQTESMBAGA1UE
+KRMJdnBuc2VydmVyMSUwIwYJKoZIhvcNAQkBFhZpbmZvQGVsYXN0aWN0dW5uZWwu
+Y29tghRz4Inn3uFX9ij/iU6+YsZ9pAdFjDATBgNVHSUEDDAKBggrBgEFBQcDAjAL
+BgNVHQ8EBAMCB4AwFAYDVR0RBA0wC4IJdnBuY2xpZW50MA0GCSqGSIb3DQEBCwUA
+A4IBAQATvHl96hCZAA8RZdMZzq0KXGjH47yA62BqydBwj23SNPJAXpUa+f20iUR1
+5FRMiRIyvAWBQyIKk9v23xyunDNU26GFlnzIUgYC4rzIiRJnOi6W4SBS7Iuk8wor
+SOQwOihHiildxLisJD9lyJ6phe0DxHlEM1urXJKc3OsHwZucHWH4yOHxHon3GdF1
+4sov5iAvyR3UfshP3izO4/X6xEnm+ANfIq9eo3i7U8x1qzeK+0FZoCi7Xx0jqfYy
+HVRjSpRkFHabb9oNBNycjLoBhwOGS8Y6ZbhwMdpvPN/ElMYYQtGhmvqZp9Pedwwh
+DWAWQfZZo5u1qQeboc9ENPiS2/Bd
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQC6buuBxxQ9/iiB
+K3F5fgDSggS9Zhwi4tzQGF86ullt6y5DjudiTAE/GkgishNQ4I5k+L9vallP+Zh/
+GuI3gjXerHNl74uxN809wZLJ6EIgXLAfmrswyp2KhSnXUMMp/BNi2i2eO8Q0z7+E
+NrwTASWXkQCQyqv8Y+nh2ynOKOf4znc+4R+cZCVxbOYb4n+kFXHi7q3J7END0uSK
+z+VzbH4lGqOKbfynaolyr68z0f5440NrMyL1TuDFyLTwKoJMpwOhucoKi2nJd1Xq
+1A3Hm43BLNNH/mefHyfxqkUeMcS8Rq+gzJs3GD4+mU+cRn0sgd5ZcmkZLi6P0D1q
+9wlJHqw/AgMBAAECggEABIDPYXgcjg7Ija4t9IBNpsgLM0P3JASUztX33uRHardG
+i80025P4Z7zLx0LD4q0540h630cTVzIxM8jDdBHKGVHTC8BIgIRXiclWMVhR2JRE
+kM7c/KW4PnNO+mtx+16iXT3l4i+RYrEt8BSeYFsjvFB9UgIDO3pyWMlBbkBgsgrI
+BaFVSvDliQJ/YOGVZnYavvbUSTdxlqdhz3BDQGc6ogB/9FUcODdIpHRf1AoBZnbt
+AKoHfEnmRXfk/+uL2pg0DrIhStRIuOJdE1kZNpaxoLzDom1X+lOFpwy60Ith161b
+EjV+Ol2V8QvX/TT/T8WuVuZ/tbGSdTdX44bfkE5V6QKBgQD3ke5mEir4G89/RrhF
+zP1jq29NPUNZ3yDmb+4adk9RxCc0Bq02o7qZ/C2s4gOAY+ZnkBa32Fih0HnXg/rC
+PFSapXbjPIp3AR3Ej5tedQqDATYiXe0fOcJ+Mz9zM6O7Vnri4ZGGGH7Lg+sNVlMi
+fqbEVS3wZk/CeZzOGFN4nHKdSwKBgQDAyA8zG5PS8vYfSr2BeWCiLYor+83Qonn2
+iIPifez5uTpGdyDoFY57jaF/lZfsIte/8eh7jpZrDD7HdXpWwyxNBkHu5a7eN5kh
+K6XqZnkSmrR8+MmTfJGMYV4Q8SdIdUn7EZ2o8++YJUmqFpHBFYS53KwyKI3crUcl
+wxJT1uWYXQKBgDGQvPsgjgvIfZ2Myh3ncZ+/1fPP3SkkHBEmvbP8ldrX+8VVxN4Y
+n6Zur7JaObs9xQZc+b9rCCu1cn9shArZS1L+57ONDmfPCGevHLsnkagy2OS+i1fi
+F4duuThWUWSTZtz/rkP7qX8TdT7hVpmkY70RFLZ5tWRJNtSoWCXgpK3LAoGAbjk0
+r5UB9SfjX0rdhUy/2ppNGQ7Uw4hSUYoGVhaHytSEJEvyrZ+9opj9ELSYc3QMhXur
+4BFLoZMTxfk+ZKMdDkEYq535WKbTT+rj51yFtwRrU9Tvc/tSQMBfBzLKshwVm46b
+5UDr6cLQFobm+U3zYE1yyw7y5YzRVB7vuK3zAiUCgYANQf7424AlLJHxyV6KTykC
+q0cqLEwKzfyo4tcAEIabUSyUhx8bZ74t9ZeBA4aztr0hSXllqXPnNma+nHtPe52U
+qRqKjYJSDZ0+iBihUGhnSZO7kguIE3ZbhE+xIkdN2a8wa4GvZOP3y2RgrqopLgZ6
+Tm0qw9kd/msS9X/ZL0URmg==
+-----END PRIVATE KEY-----
+</key>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+1b1ee2134ec91c40fd0658129ae62fc8
+35b940aec925456d5b14fde10c27b694
+59441671889a4b814934644f5163ad10
+3514fabf08bfc35ee8157210c2ae95fa
+f42463b3492e4f966263512342a50201
+c9ac55058652224421a74f431564ed1f
+388e01844b124637aa89688844a3bc08
+9485a1778137d975808f14f4fa1e0dc6
+ae8d8059d80832d8e9ae8db1ba6575aa
+571a08e975f7aa674e73ddf37afbfcac
+ec4b725c86fe447b44a0849a00b914b7
+32cb411cd6f239cd59a936a099ac017d
+2c3b38e53c1ce188f3c157ca943dfdb7
+de8296711496138873da53fbcd3052fc
+3a5e584417ed052ed8c276de7bd2ebb6
+45abbb3f31ee05a8bdf52df536068f76
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/openvpn/elastictunnel/netherlands.ovpn
+++ b/openvpn/elastictunnel/netherlands.ovpn
@@ -1,0 +1,321 @@
+##############################################
+# Sample client-side OpenVPN 2.0 config file #
+# for connecting to multi-client server.     #
+#                                            #
+# This configuration can be used by multiple #
+# clients, however each client should have   #
+# its own cert and key files.                #
+#                                            #
+# On Windows, you might want to rename this  #
+# file so it has a .ovpn extension           #
+##############################################
+
+# Specify that we are a client and that we
+# will be pulling certain config file directives
+# from the server.
+client
+
+# Use the same setting as you are using on
+# the server.
+# On most systems, the VPN will not function
+# unless you partially or fully disable
+# the firewall for the TUN/TAP interface.
+;dev tap
+dev tun
+
+# Windows needs the TAP-Win32 adapter name
+# from the Network Connections panel
+# if you have more than one.  On XP SP2,
+# you may need to disable the firewall
+# for the TAP adapter.
+;dev-node MyTap
+
+# Are we connecting to a TCP or
+# UDP server?  Use the same setting as
+# on the server.
+;proto tcp
+proto tcp
+
+# The hostname/IP and port of the server.
+# You can have multiple remote entries
+# to load balance between the servers.
+remote netherlands1.elastictunnel.com 443
+remote netherlands2.elastictunnel.com 443
+remote netherlands3.elastictunnel.com 443
+remote netherlands4.elastictunnel.com 443
+
+# Choose a random host from the remote
+# list for load-balancing.  Otherwise
+# try hosts in the order specified.
+;remote-random
+
+# Keep trying indefinitely to resolve the
+# host name of the OpenVPN server.  Very useful
+# on machines which are not permanently connected
+# to the internet such as laptops.
+resolv-retry infinite
+
+# Most clients don't need to bind to
+# a specific local port number.
+nobind
+
+# Downgrade privileges after initialization (non-Windows only)
+;user nobody
+;group nogroup
+
+# Try to preserve some state across restarts.
+persist-key
+persist-tun
+
+# If you are connecting through an
+# HTTP proxy to reach the actual OpenVPN
+# server, put the proxy server/IP and
+# port number here.  See the man page
+# if your proxy server requires
+# authentication.
+;http-proxy-retry # retry on connection failures
+;http-proxy [proxy server] [proxy port #]
+
+# Wireless networks often produce a lot
+# of duplicate packets.  Set this flag
+# to silence duplicate packet warnings.
+;mute-replay-warnings
+
+# SSL/TLS parms.
+# See the server config file for more
+# description.  It's best to use
+# a separate .crt/.key file pair
+# for each client.  A single ca
+# file can be used for all clients.
+#ca ca.crt
+#cert client.crt
+#key client.key
+
+# Verify server certificate by checking that the
+# certicate has the correct key usage set.
+# This is an important precaution to protect against
+# a potential attack discussed here:
+#  http://openvpn.net/howto.html#mitm
+#
+# To use this feature, you will need to generate
+# your server certificates with the keyUsage set to
+#   digitalSignature, keyEncipherment
+# and the extendedKeyUsage to
+#   serverAuth
+# EasyRSA can do this for you.
+remote-cert-tls server
+
+# If a tls-auth key is used on the server
+# then every client must also have the key.
+#tls-auth ta.key 1
+
+# Select a cryptographic cipher.
+# If the cipher option is used on the server
+# then you must also specify it here.
+# Note that v2.4 client/server will automatically
+# negotiate AES-256-GCM in TLS mode.
+# See also the ncp-cipher option in the manpage
+cipher AES-256-CBC
+
+# Enable compression on the VPN link.
+# Don't enable this unless it is also
+# enabled in the server config file.
+#comp-lzo
+
+# Set log file verbosity.
+verb 3
+
+# Silence repeating messages
+;mute 20
+user nobody
+group nogroup
+auth SHA256
+key-direction 1
+auth-user-pass /config/openvpn-credentials.txt
+auth-nocache
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFNzCCBB+gAwIBAgIUc+CJ597hV/Yo/4lOvmLGfaQHRYwwDQYJKoZIhvcNAQEL
+BQAwgbsxCzAJBgNVBAYTAlVBMRAwDgYDVQQIEwdLaGFya2l2MRAwDgYDVQQHEwdL
+aGFya2l2MRYwFAYDVQQKEw1lbGFzdGljdHVubmVsMRowGAYDVQQLExFlbGFzdGlj
+dHVubmVsLmNvbTEZMBcGA1UEAxMQZWxhc3RpY3R1bm5lbCBDQTESMBAGA1UEKRMJ
+dnBuc2VydmVyMSUwIwYJKoZIhvcNAQkBFhZpbmZvQGVsYXN0aWN0dW5uZWwuY29t
+MB4XDTE5MTExMjEzMTM1MFoXDTI5MTEwOTEzMTM1MFowgbsxCzAJBgNVBAYTAlVB
+MRAwDgYDVQQIEwdLaGFya2l2MRAwDgYDVQQHEwdLaGFya2l2MRYwFAYDVQQKEw1l
+bGFzdGljdHVubmVsMRowGAYDVQQLExFlbGFzdGljdHVubmVsLmNvbTEZMBcGA1UE
+AxMQZWxhc3RpY3R1bm5lbCBDQTESMBAGA1UEKRMJdnBuc2VydmVyMSUwIwYJKoZI
+hvcNAQkBFhZpbmZvQGVsYXN0aWN0dW5uZWwuY29tMIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAr3wMwbUIDH/awDltPkRCDiksWZQInj+fktqiaqGO3j/9
+sYkYAZyEra8J32r6PJd+6I993DGtYBTZUOagnMbIA288ruMNdwAeL9XJu517fxzb
+PMaMp1bKbghmDMx5vSyVyOriUhevjj7fp72zQMqjfBXwBU3U8bWBeZIvYKiCUT1n
+jRn4S7iJk3r7F8ah++teqc+qUGBad0/TZ2dub2I/j9pyDCuKTj79Hpl0EvgDrczQ
+kz7asKmQJkrMDJM5tD3wyBrIg23hOHgwy2HuufZW3tG6FtVTyXC0vrUzPWgqdRrY
+AH8De7BF5/VkFevcJDMr6hcs5nfuYwXRHWJHafd16QIDAQABo4IBLzCCASswHQYD
+VR0OBBYEFBcIWxjlIrIx/hRhFgSSxPS7uPLyMIH7BgNVHSMEgfMwgfCAFBcIWxjl
+IrIx/hRhFgSSxPS7uPLyoYHBpIG+MIG7MQswCQYDVQQGEwJVQTEQMA4GA1UECBMH
+S2hhcmtpdjEQMA4GA1UEBxMHS2hhcmtpdjEWMBQGA1UEChMNZWxhc3RpY3R1bm5l
+bDEaMBgGA1UECxMRZWxhc3RpY3R1bm5lbC5jb20xGTAXBgNVBAMTEGVsYXN0aWN0
+dW5uZWwgQ0ExEjAQBgNVBCkTCXZwbnNlcnZlcjElMCMGCSqGSIb3DQEJARYWaW5m
+b0BlbGFzdGljdHVubmVsLmNvbYIUc+CJ597hV/Yo/4lOvmLGfaQHRYwwDAYDVR0T
+BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEASZBfqX7gvSqekHb5NLmzoHaZxvIu
+E8ccMfZDg0htJUh7RTIq8V/ZW1e/D2o8xvbDcio8Z6ukZdVeI789pA29iMZSsdcr
+MfkhVehZ3Niqf5geWmk1VJ680dvnFN4X16d+QB0v0XgKNQzHG9JkOiub9xhTsna0
+FlWBQqUKrQvorHvhWwrhJHV8/eB0mOutRVZ7b61c18E/fWNtzl4w+MTcDbaWl+34
+IgSXwPQVorWedcrgU0PEHQgYOb3fADoEILIqGvODtRqePCKcIoeDzFWuERc1g+tu
+iauWS+ggvMSlRS0Dwpwm/bn9wGCTpjFLcpR/Ie9ankrDompML5x6P4J9dA==
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 2 (0x2)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=UA, ST=Kharkiv, L=Kharkiv, O=elastictunnel, OU=elastictunnel.com, CN=elastictunnel CA/name=vpnserver/emailAddress=info@elastictunnel.com
+        Validity
+            Not Before: Nov 12 13:15:49 2019 GMT
+            Not After : Nov  9 13:15:49 2029 GMT
+        Subject: C=UA, ST=Kharkiv, L=Kharkiv, O=elastictunnel, OU=elastictunnel.com, CN=vpnclient/name=vpnserver/emailAddress=info@elastictunnel.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:ba:6e:eb:81:c7:14:3d:fe:28:81:2b:71:79:7e:
+                    00:d2:82:04:bd:66:1c:22:e2:dc:d0:18:5f:3a:ba:
+                    59:6d:eb:2e:43:8e:e7:62:4c:01:3f:1a:48:22:b2:
+                    13:50:e0:8e:64:f8:bf:6f:6a:59:4f:f9:98:7f:1a:
+                    e2:37:82:35:de:ac:73:65:ef:8b:b1:37:cd:3d:c1:
+                    92:c9:e8:42:20:5c:b0:1f:9a:bb:30:ca:9d:8a:85:
+                    29:d7:50:c3:29:fc:13:62:da:2d:9e:3b:c4:34:cf:
+                    bf:84:36:bc:13:01:25:97:91:00:90:ca:ab:fc:63:
+                    e9:e1:db:29:ce:28:e7:f8:ce:77:3e:e1:1f:9c:64:
+                    25:71:6c:e6:1b:e2:7f:a4:15:71:e2:ee:ad:c9:ec:
+                    43:43:d2:e4:8a:cf:e5:73:6c:7e:25:1a:a3:8a:6d:
+                    fc:a7:6a:89:72:af:af:33:d1:fe:78:e3:43:6b:33:
+                    22:f5:4e:e0:c5:c8:b4:f0:2a:82:4c:a7:03:a1:b9:
+                    ca:0a:8b:69:c9:77:55:ea:d4:0d:c7:9b:8d:c1:2c:
+                    d3:47:fe:67:9f:1f:27:f1:aa:45:1e:31:c4:bc:46:
+                    af:a0:cc:9b:37:18:3e:3e:99:4f:9c:46:7d:2c:81:
+                    de:59:72:69:19:2e:2e:8f:d0:3d:6a:f7:09:49:1e:
+                    ac:3f
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            Netscape Comment:
+                Easy-RSA Generated Certificate
+            X509v3 Subject Key Identifier:
+                69:EB:87:03:F4:E1:1B:CA:7D:F8:05:04:BB:78:20:7F:FB:E4:BE:97
+            X509v3 Authority Key Identifier:
+                keyid:17:08:5B:18:E5:22:B2:31:FE:14:61:16:04:92:C4:F4:BB:B8:F2:F2
+                DirName:/C=UA/ST=Kharkiv/L=Kharkiv/O=elastictunnel/OU=elastictunnel.com/CN=elastictunnel CA/name=vpnserver/emailAddress=info@elastictunnel.com
+                serial:73:E0:89:E7:DE:E1:57:F6:28:FF:89:4E:BE:62:C6:7D:A4:07:45:8C
+
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication
+            X509v3 Key Usage:
+                Digital Signature
+            X509v3 Subject Alternative Name:
+                DNS:vpnclient
+    Signature Algorithm: sha256WithRSAEncryption
+         13:bc:79:7d:ea:10:99:00:0f:11:65:d3:19:ce:ad:0a:5c:68:
+         c7:e3:bc:80:eb:60:6a:c9:d0:70:8f:6d:d2:34:f2:40:5e:95:
+         1a:f9:fd:b4:89:44:75:e4:54:4c:89:12:32:bc:05:81:43:22:
+         0a:93:db:f6:df:1c:ae:9c:33:54:db:a1:85:96:7c:c8:52:06:
+         02:e2:bc:c8:89:12:67:3a:2e:96:e1:20:52:ec:8b:a4:f3:0a:
+         2b:48:e4:30:3a:28:47:8a:29:5d:c4:b8:ac:24:3f:65:c8:9e:
+         a9:85:ed:03:c4:79:44:33:5b:ab:5c:92:9c:dc:eb:07:c1:9b:
+         9c:1d:61:f8:c8:e1:f1:1e:89:f7:19:d1:75:e2:ca:2f:e6:20:
+         2f:c9:1d:d4:7e:c8:4f:de:2c:ce:e3:f5:fa:c4:49:e6:f8:03:
+         5f:22:af:5e:a3:78:bb:53:cc:75:ab:37:8a:fb:41:59:a0:28:
+         bb:5f:1d:23:a9:f6:32:1d:54:63:4a:94:64:14:76:9b:6f:da:
+         0d:04:dc:9c:8c:ba:01:87:03:86:4b:c6:3a:65:b8:70:31:da:
+         6f:3c:df:c4:94:c6:18:42:d1:a1:9a:fa:99:a7:d3:de:77:0c:
+         21:0d:60:16:41:f6:59:a3:9b:b5:a9:07:9b:a1:cf:44:34:f8:
+         92:db:f0:5d
+-----BEGIN CERTIFICATE-----
+MIIFgTCCBGmgAwIBAgIBAjANBgkqhkiG9w0BAQsFADCBuzELMAkGA1UEBhMCVUEx
+EDAOBgNVBAgTB0toYXJraXYxEDAOBgNVBAcTB0toYXJraXYxFjAUBgNVBAoTDWVs
+YXN0aWN0dW5uZWwxGjAYBgNVBAsTEWVsYXN0aWN0dW5uZWwuY29tMRkwFwYDVQQD
+ExBlbGFzdGljdHVubmVsIENBMRIwEAYDVQQpEwl2cG5zZXJ2ZXIxJTAjBgkqhkiG
+9w0BCQEWFmluZm9AZWxhc3RpY3R1bm5lbC5jb20wHhcNMTkxMTEyMTMxNTQ5WhcN
+MjkxMTA5MTMxNTQ5WjCBtDELMAkGA1UEBhMCVUExEDAOBgNVBAgTB0toYXJraXYx
+EDAOBgNVBAcTB0toYXJraXYxFjAUBgNVBAoTDWVsYXN0aWN0dW5uZWwxGjAYBgNV
+BAsTEWVsYXN0aWN0dW5uZWwuY29tMRIwEAYDVQQDEwl2cG5jbGllbnQxEjAQBgNV
+BCkTCXZwbnNlcnZlcjElMCMGCSqGSIb3DQEJARYWaW5mb0BlbGFzdGljdHVubmVs
+LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALpu64HHFD3+KIEr
+cXl+ANKCBL1mHCLi3NAYXzq6WW3rLkOO52JMAT8aSCKyE1DgjmT4v29qWU/5mH8a
+4jeCNd6sc2Xvi7E3zT3BksnoQiBcsB+auzDKnYqFKddQwyn8E2LaLZ47xDTPv4Q2
+vBMBJZeRAJDKq/xj6eHbKc4o5/jOdz7hH5xkJXFs5hvif6QVceLurcnsQ0PS5IrP
+5XNsfiUao4pt/KdqiXKvrzPR/njjQ2szIvVO4MXItPAqgkynA6G5ygqLacl3VerU
+DcebjcEs00f+Z58fJ/GqRR4xxLxGr6DMmzcYPj6ZT5xGfSyB3llyaRkuLo/QPWr3
+CUkerD8CAwEAAaOCAZMwggGPMAkGA1UdEwQCMAAwLQYJYIZIAYb4QgENBCAWHkVh
+c3ktUlNBIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4EFgQUaeuHA/ThG8p9
++AUEu3ggf/vkvpcwgfsGA1UdIwSB8zCB8IAUFwhbGOUisjH+FGEWBJLE9Lu48vKh
+gcGkgb4wgbsxCzAJBgNVBAYTAlVBMRAwDgYDVQQIEwdLaGFya2l2MRAwDgYDVQQH
+EwdLaGFya2l2MRYwFAYDVQQKEw1lbGFzdGljdHVubmVsMRowGAYDVQQLExFlbGFz
+dGljdHVubmVsLmNvbTEZMBcGA1UEAxMQZWxhc3RpY3R1bm5lbCBDQTESMBAGA1UE
+KRMJdnBuc2VydmVyMSUwIwYJKoZIhvcNAQkBFhZpbmZvQGVsYXN0aWN0dW5uZWwu
+Y29tghRz4Inn3uFX9ij/iU6+YsZ9pAdFjDATBgNVHSUEDDAKBggrBgEFBQcDAjAL
+BgNVHQ8EBAMCB4AwFAYDVR0RBA0wC4IJdnBuY2xpZW50MA0GCSqGSIb3DQEBCwUA
+A4IBAQATvHl96hCZAA8RZdMZzq0KXGjH47yA62BqydBwj23SNPJAXpUa+f20iUR1
+5FRMiRIyvAWBQyIKk9v23xyunDNU26GFlnzIUgYC4rzIiRJnOi6W4SBS7Iuk8wor
+SOQwOihHiildxLisJD9lyJ6phe0DxHlEM1urXJKc3OsHwZucHWH4yOHxHon3GdF1
+4sov5iAvyR3UfshP3izO4/X6xEnm+ANfIq9eo3i7U8x1qzeK+0FZoCi7Xx0jqfYy
+HVRjSpRkFHabb9oNBNycjLoBhwOGS8Y6ZbhwMdpvPN/ElMYYQtGhmvqZp9Pedwwh
+DWAWQfZZo5u1qQeboc9ENPiS2/Bd
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQC6buuBxxQ9/iiB
+K3F5fgDSggS9Zhwi4tzQGF86ullt6y5DjudiTAE/GkgishNQ4I5k+L9vallP+Zh/
+GuI3gjXerHNl74uxN809wZLJ6EIgXLAfmrswyp2KhSnXUMMp/BNi2i2eO8Q0z7+E
+NrwTASWXkQCQyqv8Y+nh2ynOKOf4znc+4R+cZCVxbOYb4n+kFXHi7q3J7END0uSK
+z+VzbH4lGqOKbfynaolyr68z0f5440NrMyL1TuDFyLTwKoJMpwOhucoKi2nJd1Xq
+1A3Hm43BLNNH/mefHyfxqkUeMcS8Rq+gzJs3GD4+mU+cRn0sgd5ZcmkZLi6P0D1q
+9wlJHqw/AgMBAAECggEABIDPYXgcjg7Ija4t9IBNpsgLM0P3JASUztX33uRHardG
+i80025P4Z7zLx0LD4q0540h630cTVzIxM8jDdBHKGVHTC8BIgIRXiclWMVhR2JRE
+kM7c/KW4PnNO+mtx+16iXT3l4i+RYrEt8BSeYFsjvFB9UgIDO3pyWMlBbkBgsgrI
+BaFVSvDliQJ/YOGVZnYavvbUSTdxlqdhz3BDQGc6ogB/9FUcODdIpHRf1AoBZnbt
+AKoHfEnmRXfk/+uL2pg0DrIhStRIuOJdE1kZNpaxoLzDom1X+lOFpwy60Ith161b
+EjV+Ol2V8QvX/TT/T8WuVuZ/tbGSdTdX44bfkE5V6QKBgQD3ke5mEir4G89/RrhF
+zP1jq29NPUNZ3yDmb+4adk9RxCc0Bq02o7qZ/C2s4gOAY+ZnkBa32Fih0HnXg/rC
+PFSapXbjPIp3AR3Ej5tedQqDATYiXe0fOcJ+Mz9zM6O7Vnri4ZGGGH7Lg+sNVlMi
+fqbEVS3wZk/CeZzOGFN4nHKdSwKBgQDAyA8zG5PS8vYfSr2BeWCiLYor+83Qonn2
+iIPifez5uTpGdyDoFY57jaF/lZfsIte/8eh7jpZrDD7HdXpWwyxNBkHu5a7eN5kh
+K6XqZnkSmrR8+MmTfJGMYV4Q8SdIdUn7EZ2o8++YJUmqFpHBFYS53KwyKI3crUcl
+wxJT1uWYXQKBgDGQvPsgjgvIfZ2Myh3ncZ+/1fPP3SkkHBEmvbP8ldrX+8VVxN4Y
+n6Zur7JaObs9xQZc+b9rCCu1cn9shArZS1L+57ONDmfPCGevHLsnkagy2OS+i1fi
+F4duuThWUWSTZtz/rkP7qX8TdT7hVpmkY70RFLZ5tWRJNtSoWCXgpK3LAoGAbjk0
+r5UB9SfjX0rdhUy/2ppNGQ7Uw4hSUYoGVhaHytSEJEvyrZ+9opj9ELSYc3QMhXur
+4BFLoZMTxfk+ZKMdDkEYq535WKbTT+rj51yFtwRrU9Tvc/tSQMBfBzLKshwVm46b
+5UDr6cLQFobm+U3zYE1yyw7y5YzRVB7vuK3zAiUCgYANQf7424AlLJHxyV6KTykC
+q0cqLEwKzfyo4tcAEIabUSyUhx8bZ74t9ZeBA4aztr0hSXllqXPnNma+nHtPe52U
+qRqKjYJSDZ0+iBihUGhnSZO7kguIE3ZbhE+xIkdN2a8wa4GvZOP3y2RgrqopLgZ6
+Tm0qw9kd/msS9X/ZL0URmg==
+-----END PRIVATE KEY-----
+</key>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+1b1ee2134ec91c40fd0658129ae62fc8
+35b940aec925456d5b14fde10c27b694
+59441671889a4b814934644f5163ad10
+3514fabf08bfc35ee8157210c2ae95fa
+f42463b3492e4f966263512342a50201
+c9ac55058652224421a74f431564ed1f
+388e01844b124637aa89688844a3bc08
+9485a1778137d975808f14f4fa1e0dc6
+ae8d8059d80832d8e9ae8db1ba6575aa
+571a08e975f7aa674e73ddf37afbfcac
+ec4b725c86fe447b44a0849a00b914b7
+32cb411cd6f239cd59a936a099ac017d
+2c3b38e53c1ce188f3c157ca943dfdb7
+de8296711496138873da53fbcd3052fc
+3a5e584417ed052ed8c276de7bd2ebb6
+45abbb3f31ee05a8bdf52df536068f76
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/openvpn/elastictunnel/uk_london.ovpn
+++ b/openvpn/elastictunnel/uk_london.ovpn
@@ -1,0 +1,321 @@
+##############################################
+# Sample client-side OpenVPN 2.0 config file #
+# for connecting to multi-client server.     #
+#                                            #
+# This configuration can be used by multiple #
+# clients, however each client should have   #
+# its own cert and key files.                #
+#                                            #
+# On Windows, you might want to rename this  #
+# file so it has a .ovpn extension           #
+##############################################
+
+# Specify that we are a client and that we
+# will be pulling certain config file directives
+# from the server.
+client
+
+# Use the same setting as you are using on
+# the server.
+# On most systems, the VPN will not function
+# unless you partially or fully disable
+# the firewall for the TUN/TAP interface.
+;dev tap
+dev tun
+
+# Windows needs the TAP-Win32 adapter name
+# from the Network Connections panel
+# if you have more than one.  On XP SP2,
+# you may need to disable the firewall
+# for the TAP adapter.
+;dev-node MyTap
+
+# Are we connecting to a TCP or
+# UDP server?  Use the same setting as
+# on the server.
+;proto tcp
+proto tcp
+
+# The hostname/IP and port of the server.
+# You can have multiple remote entries
+# to load balance between the servers.
+remote uk_london1.elastictunnel.com 443
+remote uk_london2.elastictunnel.com 443
+remote uk_london3.elastictunnel.com 443
+remote uk_london4.elastictunnel.com 443
+
+# Choose a random host from the remote
+# list for load-balancing.  Otherwise
+# try hosts in the order specified.
+;remote-random
+
+# Keep trying indefinitely to resolve the
+# host name of the OpenVPN server.  Very useful
+# on machines which are not permanently connected
+# to the internet such as laptops.
+resolv-retry infinite
+
+# Most clients don't need to bind to
+# a specific local port number.
+nobind
+
+# Downgrade privileges after initialization (non-Windows only)
+;user nobody
+;group nogroup
+
+# Try to preserve some state across restarts.
+persist-key
+persist-tun
+
+# If you are connecting through an
+# HTTP proxy to reach the actual OpenVPN
+# server, put the proxy server/IP and
+# port number here.  See the man page
+# if your proxy server requires
+# authentication.
+;http-proxy-retry # retry on connection failures
+;http-proxy [proxy server] [proxy port #]
+
+# Wireless networks often produce a lot
+# of duplicate packets.  Set this flag
+# to silence duplicate packet warnings.
+;mute-replay-warnings
+
+# SSL/TLS parms.
+# See the server config file for more
+# description.  It's best to use
+# a separate .crt/.key file pair
+# for each client.  A single ca
+# file can be used for all clients.
+#ca ca.crt
+#cert client.crt
+#key client.key
+
+# Verify server certificate by checking that the
+# certicate has the correct key usage set.
+# This is an important precaution to protect against
+# a potential attack discussed here:
+#  http://openvpn.net/howto.html#mitm
+#
+# To use this feature, you will need to generate
+# your server certificates with the keyUsage set to
+#   digitalSignature, keyEncipherment
+# and the extendedKeyUsage to
+#   serverAuth
+# EasyRSA can do this for you.
+remote-cert-tls server
+
+# If a tls-auth key is used on the server
+# then every client must also have the key.
+#tls-auth ta.key 1
+
+# Select a cryptographic cipher.
+# If the cipher option is used on the server
+# then you must also specify it here.
+# Note that v2.4 client/server will automatically
+# negotiate AES-256-GCM in TLS mode.
+# See also the ncp-cipher option in the manpage
+cipher AES-256-CBC
+
+# Enable compression on the VPN link.
+# Don't enable this unless it is also
+# enabled in the server config file.
+#comp-lzo
+
+# Set log file verbosity.
+verb 3
+
+# Silence repeating messages
+;mute 20
+user nobody
+group nogroup
+auth SHA256
+key-direction 1
+auth-user-pass /config/openvpn-credentials.txt
+auth-nocache
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFNzCCBB+gAwIBAgIUc+CJ597hV/Yo/4lOvmLGfaQHRYwwDQYJKoZIhvcNAQEL
+BQAwgbsxCzAJBgNVBAYTAlVBMRAwDgYDVQQIEwdLaGFya2l2MRAwDgYDVQQHEwdL
+aGFya2l2MRYwFAYDVQQKEw1lbGFzdGljdHVubmVsMRowGAYDVQQLExFlbGFzdGlj
+dHVubmVsLmNvbTEZMBcGA1UEAxMQZWxhc3RpY3R1bm5lbCBDQTESMBAGA1UEKRMJ
+dnBuc2VydmVyMSUwIwYJKoZIhvcNAQkBFhZpbmZvQGVsYXN0aWN0dW5uZWwuY29t
+MB4XDTE5MTExMjEzMTM1MFoXDTI5MTEwOTEzMTM1MFowgbsxCzAJBgNVBAYTAlVB
+MRAwDgYDVQQIEwdLaGFya2l2MRAwDgYDVQQHEwdLaGFya2l2MRYwFAYDVQQKEw1l
+bGFzdGljdHVubmVsMRowGAYDVQQLExFlbGFzdGljdHVubmVsLmNvbTEZMBcGA1UE
+AxMQZWxhc3RpY3R1bm5lbCBDQTESMBAGA1UEKRMJdnBuc2VydmVyMSUwIwYJKoZI
+hvcNAQkBFhZpbmZvQGVsYXN0aWN0dW5uZWwuY29tMIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAr3wMwbUIDH/awDltPkRCDiksWZQInj+fktqiaqGO3j/9
+sYkYAZyEra8J32r6PJd+6I993DGtYBTZUOagnMbIA288ruMNdwAeL9XJu517fxzb
+PMaMp1bKbghmDMx5vSyVyOriUhevjj7fp72zQMqjfBXwBU3U8bWBeZIvYKiCUT1n
+jRn4S7iJk3r7F8ah++teqc+qUGBad0/TZ2dub2I/j9pyDCuKTj79Hpl0EvgDrczQ
+kz7asKmQJkrMDJM5tD3wyBrIg23hOHgwy2HuufZW3tG6FtVTyXC0vrUzPWgqdRrY
+AH8De7BF5/VkFevcJDMr6hcs5nfuYwXRHWJHafd16QIDAQABo4IBLzCCASswHQYD
+VR0OBBYEFBcIWxjlIrIx/hRhFgSSxPS7uPLyMIH7BgNVHSMEgfMwgfCAFBcIWxjl
+IrIx/hRhFgSSxPS7uPLyoYHBpIG+MIG7MQswCQYDVQQGEwJVQTEQMA4GA1UECBMH
+S2hhcmtpdjEQMA4GA1UEBxMHS2hhcmtpdjEWMBQGA1UEChMNZWxhc3RpY3R1bm5l
+bDEaMBgGA1UECxMRZWxhc3RpY3R1bm5lbC5jb20xGTAXBgNVBAMTEGVsYXN0aWN0
+dW5uZWwgQ0ExEjAQBgNVBCkTCXZwbnNlcnZlcjElMCMGCSqGSIb3DQEJARYWaW5m
+b0BlbGFzdGljdHVubmVsLmNvbYIUc+CJ597hV/Yo/4lOvmLGfaQHRYwwDAYDVR0T
+BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEASZBfqX7gvSqekHb5NLmzoHaZxvIu
+E8ccMfZDg0htJUh7RTIq8V/ZW1e/D2o8xvbDcio8Z6ukZdVeI789pA29iMZSsdcr
+MfkhVehZ3Niqf5geWmk1VJ680dvnFN4X16d+QB0v0XgKNQzHG9JkOiub9xhTsna0
+FlWBQqUKrQvorHvhWwrhJHV8/eB0mOutRVZ7b61c18E/fWNtzl4w+MTcDbaWl+34
+IgSXwPQVorWedcrgU0PEHQgYOb3fADoEILIqGvODtRqePCKcIoeDzFWuERc1g+tu
+iauWS+ggvMSlRS0Dwpwm/bn9wGCTpjFLcpR/Ie9ankrDompML5x6P4J9dA==
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 2 (0x2)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=UA, ST=Kharkiv, L=Kharkiv, O=elastictunnel, OU=elastictunnel.com, CN=elastictunnel CA/name=vpnserver/emailAddress=info@elastictunnel.com
+        Validity
+            Not Before: Nov 12 13:15:49 2019 GMT
+            Not After : Nov  9 13:15:49 2029 GMT
+        Subject: C=UA, ST=Kharkiv, L=Kharkiv, O=elastictunnel, OU=elastictunnel.com, CN=vpnclient/name=vpnserver/emailAddress=info@elastictunnel.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:ba:6e:eb:81:c7:14:3d:fe:28:81:2b:71:79:7e:
+                    00:d2:82:04:bd:66:1c:22:e2:dc:d0:18:5f:3a:ba:
+                    59:6d:eb:2e:43:8e:e7:62:4c:01:3f:1a:48:22:b2:
+                    13:50:e0:8e:64:f8:bf:6f:6a:59:4f:f9:98:7f:1a:
+                    e2:37:82:35:de:ac:73:65:ef:8b:b1:37:cd:3d:c1:
+                    92:c9:e8:42:20:5c:b0:1f:9a:bb:30:ca:9d:8a:85:
+                    29:d7:50:c3:29:fc:13:62:da:2d:9e:3b:c4:34:cf:
+                    bf:84:36:bc:13:01:25:97:91:00:90:ca:ab:fc:63:
+                    e9:e1:db:29:ce:28:e7:f8:ce:77:3e:e1:1f:9c:64:
+                    25:71:6c:e6:1b:e2:7f:a4:15:71:e2:ee:ad:c9:ec:
+                    43:43:d2:e4:8a:cf:e5:73:6c:7e:25:1a:a3:8a:6d:
+                    fc:a7:6a:89:72:af:af:33:d1:fe:78:e3:43:6b:33:
+                    22:f5:4e:e0:c5:c8:b4:f0:2a:82:4c:a7:03:a1:b9:
+                    ca:0a:8b:69:c9:77:55:ea:d4:0d:c7:9b:8d:c1:2c:
+                    d3:47:fe:67:9f:1f:27:f1:aa:45:1e:31:c4:bc:46:
+                    af:a0:cc:9b:37:18:3e:3e:99:4f:9c:46:7d:2c:81:
+                    de:59:72:69:19:2e:2e:8f:d0:3d:6a:f7:09:49:1e:
+                    ac:3f
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            Netscape Comment:
+                Easy-RSA Generated Certificate
+            X509v3 Subject Key Identifier:
+                69:EB:87:03:F4:E1:1B:CA:7D:F8:05:04:BB:78:20:7F:FB:E4:BE:97
+            X509v3 Authority Key Identifier:
+                keyid:17:08:5B:18:E5:22:B2:31:FE:14:61:16:04:92:C4:F4:BB:B8:F2:F2
+                DirName:/C=UA/ST=Kharkiv/L=Kharkiv/O=elastictunnel/OU=elastictunnel.com/CN=elastictunnel CA/name=vpnserver/emailAddress=info@elastictunnel.com
+                serial:73:E0:89:E7:DE:E1:57:F6:28:FF:89:4E:BE:62:C6:7D:A4:07:45:8C
+
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication
+            X509v3 Key Usage:
+                Digital Signature
+            X509v3 Subject Alternative Name:
+                DNS:vpnclient
+    Signature Algorithm: sha256WithRSAEncryption
+         13:bc:79:7d:ea:10:99:00:0f:11:65:d3:19:ce:ad:0a:5c:68:
+         c7:e3:bc:80:eb:60:6a:c9:d0:70:8f:6d:d2:34:f2:40:5e:95:
+         1a:f9:fd:b4:89:44:75:e4:54:4c:89:12:32:bc:05:81:43:22:
+         0a:93:db:f6:df:1c:ae:9c:33:54:db:a1:85:96:7c:c8:52:06:
+         02:e2:bc:c8:89:12:67:3a:2e:96:e1:20:52:ec:8b:a4:f3:0a:
+         2b:48:e4:30:3a:28:47:8a:29:5d:c4:b8:ac:24:3f:65:c8:9e:
+         a9:85:ed:03:c4:79:44:33:5b:ab:5c:92:9c:dc:eb:07:c1:9b:
+         9c:1d:61:f8:c8:e1:f1:1e:89:f7:19:d1:75:e2:ca:2f:e6:20:
+         2f:c9:1d:d4:7e:c8:4f:de:2c:ce:e3:f5:fa:c4:49:e6:f8:03:
+         5f:22:af:5e:a3:78:bb:53:cc:75:ab:37:8a:fb:41:59:a0:28:
+         bb:5f:1d:23:a9:f6:32:1d:54:63:4a:94:64:14:76:9b:6f:da:
+         0d:04:dc:9c:8c:ba:01:87:03:86:4b:c6:3a:65:b8:70:31:da:
+         6f:3c:df:c4:94:c6:18:42:d1:a1:9a:fa:99:a7:d3:de:77:0c:
+         21:0d:60:16:41:f6:59:a3:9b:b5:a9:07:9b:a1:cf:44:34:f8:
+         92:db:f0:5d
+-----BEGIN CERTIFICATE-----
+MIIFgTCCBGmgAwIBAgIBAjANBgkqhkiG9w0BAQsFADCBuzELMAkGA1UEBhMCVUEx
+EDAOBgNVBAgTB0toYXJraXYxEDAOBgNVBAcTB0toYXJraXYxFjAUBgNVBAoTDWVs
+YXN0aWN0dW5uZWwxGjAYBgNVBAsTEWVsYXN0aWN0dW5uZWwuY29tMRkwFwYDVQQD
+ExBlbGFzdGljdHVubmVsIENBMRIwEAYDVQQpEwl2cG5zZXJ2ZXIxJTAjBgkqhkiG
+9w0BCQEWFmluZm9AZWxhc3RpY3R1bm5lbC5jb20wHhcNMTkxMTEyMTMxNTQ5WhcN
+MjkxMTA5MTMxNTQ5WjCBtDELMAkGA1UEBhMCVUExEDAOBgNVBAgTB0toYXJraXYx
+EDAOBgNVBAcTB0toYXJraXYxFjAUBgNVBAoTDWVsYXN0aWN0dW5uZWwxGjAYBgNV
+BAsTEWVsYXN0aWN0dW5uZWwuY29tMRIwEAYDVQQDEwl2cG5jbGllbnQxEjAQBgNV
+BCkTCXZwbnNlcnZlcjElMCMGCSqGSIb3DQEJARYWaW5mb0BlbGFzdGljdHVubmVs
+LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALpu64HHFD3+KIEr
+cXl+ANKCBL1mHCLi3NAYXzq6WW3rLkOO52JMAT8aSCKyE1DgjmT4v29qWU/5mH8a
+4jeCNd6sc2Xvi7E3zT3BksnoQiBcsB+auzDKnYqFKddQwyn8E2LaLZ47xDTPv4Q2
+vBMBJZeRAJDKq/xj6eHbKc4o5/jOdz7hH5xkJXFs5hvif6QVceLurcnsQ0PS5IrP
+5XNsfiUao4pt/KdqiXKvrzPR/njjQ2szIvVO4MXItPAqgkynA6G5ygqLacl3VerU
+DcebjcEs00f+Z58fJ/GqRR4xxLxGr6DMmzcYPj6ZT5xGfSyB3llyaRkuLo/QPWr3
+CUkerD8CAwEAAaOCAZMwggGPMAkGA1UdEwQCMAAwLQYJYIZIAYb4QgENBCAWHkVh
+c3ktUlNBIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4EFgQUaeuHA/ThG8p9
++AUEu3ggf/vkvpcwgfsGA1UdIwSB8zCB8IAUFwhbGOUisjH+FGEWBJLE9Lu48vKh
+gcGkgb4wgbsxCzAJBgNVBAYTAlVBMRAwDgYDVQQIEwdLaGFya2l2MRAwDgYDVQQH
+EwdLaGFya2l2MRYwFAYDVQQKEw1lbGFzdGljdHVubmVsMRowGAYDVQQLExFlbGFz
+dGljdHVubmVsLmNvbTEZMBcGA1UEAxMQZWxhc3RpY3R1bm5lbCBDQTESMBAGA1UE
+KRMJdnBuc2VydmVyMSUwIwYJKoZIhvcNAQkBFhZpbmZvQGVsYXN0aWN0dW5uZWwu
+Y29tghRz4Inn3uFX9ij/iU6+YsZ9pAdFjDATBgNVHSUEDDAKBggrBgEFBQcDAjAL
+BgNVHQ8EBAMCB4AwFAYDVR0RBA0wC4IJdnBuY2xpZW50MA0GCSqGSIb3DQEBCwUA
+A4IBAQATvHl96hCZAA8RZdMZzq0KXGjH47yA62BqydBwj23SNPJAXpUa+f20iUR1
+5FRMiRIyvAWBQyIKk9v23xyunDNU26GFlnzIUgYC4rzIiRJnOi6W4SBS7Iuk8wor
+SOQwOihHiildxLisJD9lyJ6phe0DxHlEM1urXJKc3OsHwZucHWH4yOHxHon3GdF1
+4sov5iAvyR3UfshP3izO4/X6xEnm+ANfIq9eo3i7U8x1qzeK+0FZoCi7Xx0jqfYy
+HVRjSpRkFHabb9oNBNycjLoBhwOGS8Y6ZbhwMdpvPN/ElMYYQtGhmvqZp9Pedwwh
+DWAWQfZZo5u1qQeboc9ENPiS2/Bd
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQC6buuBxxQ9/iiB
+K3F5fgDSggS9Zhwi4tzQGF86ullt6y5DjudiTAE/GkgishNQ4I5k+L9vallP+Zh/
+GuI3gjXerHNl74uxN809wZLJ6EIgXLAfmrswyp2KhSnXUMMp/BNi2i2eO8Q0z7+E
+NrwTASWXkQCQyqv8Y+nh2ynOKOf4znc+4R+cZCVxbOYb4n+kFXHi7q3J7END0uSK
+z+VzbH4lGqOKbfynaolyr68z0f5440NrMyL1TuDFyLTwKoJMpwOhucoKi2nJd1Xq
+1A3Hm43BLNNH/mefHyfxqkUeMcS8Rq+gzJs3GD4+mU+cRn0sgd5ZcmkZLi6P0D1q
+9wlJHqw/AgMBAAECggEABIDPYXgcjg7Ija4t9IBNpsgLM0P3JASUztX33uRHardG
+i80025P4Z7zLx0LD4q0540h630cTVzIxM8jDdBHKGVHTC8BIgIRXiclWMVhR2JRE
+kM7c/KW4PnNO+mtx+16iXT3l4i+RYrEt8BSeYFsjvFB9UgIDO3pyWMlBbkBgsgrI
+BaFVSvDliQJ/YOGVZnYavvbUSTdxlqdhz3BDQGc6ogB/9FUcODdIpHRf1AoBZnbt
+AKoHfEnmRXfk/+uL2pg0DrIhStRIuOJdE1kZNpaxoLzDom1X+lOFpwy60Ith161b
+EjV+Ol2V8QvX/TT/T8WuVuZ/tbGSdTdX44bfkE5V6QKBgQD3ke5mEir4G89/RrhF
+zP1jq29NPUNZ3yDmb+4adk9RxCc0Bq02o7qZ/C2s4gOAY+ZnkBa32Fih0HnXg/rC
+PFSapXbjPIp3AR3Ej5tedQqDATYiXe0fOcJ+Mz9zM6O7Vnri4ZGGGH7Lg+sNVlMi
+fqbEVS3wZk/CeZzOGFN4nHKdSwKBgQDAyA8zG5PS8vYfSr2BeWCiLYor+83Qonn2
+iIPifez5uTpGdyDoFY57jaF/lZfsIte/8eh7jpZrDD7HdXpWwyxNBkHu5a7eN5kh
+K6XqZnkSmrR8+MmTfJGMYV4Q8SdIdUn7EZ2o8++YJUmqFpHBFYS53KwyKI3crUcl
+wxJT1uWYXQKBgDGQvPsgjgvIfZ2Myh3ncZ+/1fPP3SkkHBEmvbP8ldrX+8VVxN4Y
+n6Zur7JaObs9xQZc+b9rCCu1cn9shArZS1L+57ONDmfPCGevHLsnkagy2OS+i1fi
+F4duuThWUWSTZtz/rkP7qX8TdT7hVpmkY70RFLZ5tWRJNtSoWCXgpK3LAoGAbjk0
+r5UB9SfjX0rdhUy/2ppNGQ7Uw4hSUYoGVhaHytSEJEvyrZ+9opj9ELSYc3QMhXur
+4BFLoZMTxfk+ZKMdDkEYq535WKbTT+rj51yFtwRrU9Tvc/tSQMBfBzLKshwVm46b
+5UDr6cLQFobm+U3zYE1yyw7y5YzRVB7vuK3zAiUCgYANQf7424AlLJHxyV6KTykC
+q0cqLEwKzfyo4tcAEIabUSyUhx8bZ74t9ZeBA4aztr0hSXllqXPnNma+nHtPe52U
+qRqKjYJSDZ0+iBihUGhnSZO7kguIE3ZbhE+xIkdN2a8wa4GvZOP3y2RgrqopLgZ6
+Tm0qw9kd/msS9X/ZL0URmg==
+-----END PRIVATE KEY-----
+</key>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+1b1ee2134ec91c40fd0658129ae62fc8
+35b940aec925456d5b14fde10c27b694
+59441671889a4b814934644f5163ad10
+3514fabf08bfc35ee8157210c2ae95fa
+f42463b3492e4f966263512342a50201
+c9ac55058652224421a74f431564ed1f
+388e01844b124637aa89688844a3bc08
+9485a1778137d975808f14f4fa1e0dc6
+ae8d8059d80832d8e9ae8db1ba6575aa
+571a08e975f7aa674e73ddf37afbfcac
+ec4b725c86fe447b44a0849a00b914b7
+32cb411cd6f239cd59a936a099ac017d
+2c3b38e53c1ce188f3c157ca943dfdb7
+de8296711496138873da53fbcd3052fc
+3a5e584417ed052ed8c276de7bd2ebb6
+45abbb3f31ee05a8bdf52df536068f76
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/openvpn/elastictunnel/ukraine.ovpn
+++ b/openvpn/elastictunnel/ukraine.ovpn
@@ -1,0 +1,321 @@
+##############################################
+# Sample client-side OpenVPN 2.0 config file #
+# for connecting to multi-client server.     #
+#                                            #
+# This configuration can be used by multiple #
+# clients, however each client should have   #
+# its own cert and key files.                #
+#                                            #
+# On Windows, you might want to rename this  #
+# file so it has a .ovpn extension           #
+##############################################
+
+# Specify that we are a client and that we
+# will be pulling certain config file directives
+# from the server.
+client
+
+# Use the same setting as you are using on
+# the server.
+# On most systems, the VPN will not function
+# unless you partially or fully disable
+# the firewall for the TUN/TAP interface.
+;dev tap
+dev tun
+
+# Windows needs the TAP-Win32 adapter name
+# from the Network Connections panel
+# if you have more than one.  On XP SP2,
+# you may need to disable the firewall
+# for the TAP adapter.
+;dev-node MyTap
+
+# Are we connecting to a TCP or
+# UDP server?  Use the same setting as
+# on the server.
+;proto tcp
+proto tcp
+
+# The hostname/IP and port of the server.
+# You can have multiple remote entries
+# to load balance between the servers.
+remote ukraine1.elastictunnel.com 443
+remote ukraine2.elastictunnel.com 443
+remote ukraine3.elastictunnel.com 443
+remote ukraine4.elastictunnel.com 443
+
+# Choose a random host from the remote
+# list for load-balancing.  Otherwise
+# try hosts in the order specified.
+;remote-random
+
+# Keep trying indefinitely to resolve the
+# host name of the OpenVPN server.  Very useful
+# on machines which are not permanently connected
+# to the internet such as laptops.
+resolv-retry infinite
+
+# Most clients don't need to bind to
+# a specific local port number.
+nobind
+
+# Downgrade privileges after initialization (non-Windows only)
+;user nobody
+;group nogroup
+
+# Try to preserve some state across restarts.
+persist-key
+persist-tun
+
+# If you are connecting through an
+# HTTP proxy to reach the actual OpenVPN
+# server, put the proxy server/IP and
+# port number here.  See the man page
+# if your proxy server requires
+# authentication.
+;http-proxy-retry # retry on connection failures
+;http-proxy [proxy server] [proxy port #]
+
+# Wireless networks often produce a lot
+# of duplicate packets.  Set this flag
+# to silence duplicate packet warnings.
+;mute-replay-warnings
+
+# SSL/TLS parms.
+# See the server config file for more
+# description.  It's best to use
+# a separate .crt/.key file pair
+# for each client.  A single ca
+# file can be used for all clients.
+#ca ca.crt
+#cert client.crt
+#key client.key
+
+# Verify server certificate by checking that the
+# certicate has the correct key usage set.
+# This is an important precaution to protect against
+# a potential attack discussed here:
+#  http://openvpn.net/howto.html#mitm
+#
+# To use this feature, you will need to generate
+# your server certificates with the keyUsage set to
+#   digitalSignature, keyEncipherment
+# and the extendedKeyUsage to
+#   serverAuth
+# EasyRSA can do this for you.
+remote-cert-tls server
+
+# If a tls-auth key is used on the server
+# then every client must also have the key.
+#tls-auth ta.key 1
+
+# Select a cryptographic cipher.
+# If the cipher option is used on the server
+# then you must also specify it here.
+# Note that v2.4 client/server will automatically
+# negotiate AES-256-GCM in TLS mode.
+# See also the ncp-cipher option in the manpage
+cipher AES-256-CBC
+
+# Enable compression on the VPN link.
+# Don't enable this unless it is also
+# enabled in the server config file.
+#comp-lzo
+
+# Set log file verbosity.
+verb 3
+
+# Silence repeating messages
+;mute 20
+user nobody
+group nogroup
+auth SHA256
+key-direction 1
+auth-user-pass /config/openvpn-credentials.txt
+auth-nocache
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFNzCCBB+gAwIBAgIUc+CJ597hV/Yo/4lOvmLGfaQHRYwwDQYJKoZIhvcNAQEL
+BQAwgbsxCzAJBgNVBAYTAlVBMRAwDgYDVQQIEwdLaGFya2l2MRAwDgYDVQQHEwdL
+aGFya2l2MRYwFAYDVQQKEw1lbGFzdGljdHVubmVsMRowGAYDVQQLExFlbGFzdGlj
+dHVubmVsLmNvbTEZMBcGA1UEAxMQZWxhc3RpY3R1bm5lbCBDQTESMBAGA1UEKRMJ
+dnBuc2VydmVyMSUwIwYJKoZIhvcNAQkBFhZpbmZvQGVsYXN0aWN0dW5uZWwuY29t
+MB4XDTE5MTExMjEzMTM1MFoXDTI5MTEwOTEzMTM1MFowgbsxCzAJBgNVBAYTAlVB
+MRAwDgYDVQQIEwdLaGFya2l2MRAwDgYDVQQHEwdLaGFya2l2MRYwFAYDVQQKEw1l
+bGFzdGljdHVubmVsMRowGAYDVQQLExFlbGFzdGljdHVubmVsLmNvbTEZMBcGA1UE
+AxMQZWxhc3RpY3R1bm5lbCBDQTESMBAGA1UEKRMJdnBuc2VydmVyMSUwIwYJKoZI
+hvcNAQkBFhZpbmZvQGVsYXN0aWN0dW5uZWwuY29tMIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAr3wMwbUIDH/awDltPkRCDiksWZQInj+fktqiaqGO3j/9
+sYkYAZyEra8J32r6PJd+6I993DGtYBTZUOagnMbIA288ruMNdwAeL9XJu517fxzb
+PMaMp1bKbghmDMx5vSyVyOriUhevjj7fp72zQMqjfBXwBU3U8bWBeZIvYKiCUT1n
+jRn4S7iJk3r7F8ah++teqc+qUGBad0/TZ2dub2I/j9pyDCuKTj79Hpl0EvgDrczQ
+kz7asKmQJkrMDJM5tD3wyBrIg23hOHgwy2HuufZW3tG6FtVTyXC0vrUzPWgqdRrY
+AH8De7BF5/VkFevcJDMr6hcs5nfuYwXRHWJHafd16QIDAQABo4IBLzCCASswHQYD
+VR0OBBYEFBcIWxjlIrIx/hRhFgSSxPS7uPLyMIH7BgNVHSMEgfMwgfCAFBcIWxjl
+IrIx/hRhFgSSxPS7uPLyoYHBpIG+MIG7MQswCQYDVQQGEwJVQTEQMA4GA1UECBMH
+S2hhcmtpdjEQMA4GA1UEBxMHS2hhcmtpdjEWMBQGA1UEChMNZWxhc3RpY3R1bm5l
+bDEaMBgGA1UECxMRZWxhc3RpY3R1bm5lbC5jb20xGTAXBgNVBAMTEGVsYXN0aWN0
+dW5uZWwgQ0ExEjAQBgNVBCkTCXZwbnNlcnZlcjElMCMGCSqGSIb3DQEJARYWaW5m
+b0BlbGFzdGljdHVubmVsLmNvbYIUc+CJ597hV/Yo/4lOvmLGfaQHRYwwDAYDVR0T
+BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEASZBfqX7gvSqekHb5NLmzoHaZxvIu
+E8ccMfZDg0htJUh7RTIq8V/ZW1e/D2o8xvbDcio8Z6ukZdVeI789pA29iMZSsdcr
+MfkhVehZ3Niqf5geWmk1VJ680dvnFN4X16d+QB0v0XgKNQzHG9JkOiub9xhTsna0
+FlWBQqUKrQvorHvhWwrhJHV8/eB0mOutRVZ7b61c18E/fWNtzl4w+MTcDbaWl+34
+IgSXwPQVorWedcrgU0PEHQgYOb3fADoEILIqGvODtRqePCKcIoeDzFWuERc1g+tu
+iauWS+ggvMSlRS0Dwpwm/bn9wGCTpjFLcpR/Ie9ankrDompML5x6P4J9dA==
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 2 (0x2)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=UA, ST=Kharkiv, L=Kharkiv, O=elastictunnel, OU=elastictunnel.com, CN=elastictunnel CA/name=vpnserver/emailAddress=info@elastictunnel.com
+        Validity
+            Not Before: Nov 12 13:15:49 2019 GMT
+            Not After : Nov  9 13:15:49 2029 GMT
+        Subject: C=UA, ST=Kharkiv, L=Kharkiv, O=elastictunnel, OU=elastictunnel.com, CN=vpnclient/name=vpnserver/emailAddress=info@elastictunnel.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:ba:6e:eb:81:c7:14:3d:fe:28:81:2b:71:79:7e:
+                    00:d2:82:04:bd:66:1c:22:e2:dc:d0:18:5f:3a:ba:
+                    59:6d:eb:2e:43:8e:e7:62:4c:01:3f:1a:48:22:b2:
+                    13:50:e0:8e:64:f8:bf:6f:6a:59:4f:f9:98:7f:1a:
+                    e2:37:82:35:de:ac:73:65:ef:8b:b1:37:cd:3d:c1:
+                    92:c9:e8:42:20:5c:b0:1f:9a:bb:30:ca:9d:8a:85:
+                    29:d7:50:c3:29:fc:13:62:da:2d:9e:3b:c4:34:cf:
+                    bf:84:36:bc:13:01:25:97:91:00:90:ca:ab:fc:63:
+                    e9:e1:db:29:ce:28:e7:f8:ce:77:3e:e1:1f:9c:64:
+                    25:71:6c:e6:1b:e2:7f:a4:15:71:e2:ee:ad:c9:ec:
+                    43:43:d2:e4:8a:cf:e5:73:6c:7e:25:1a:a3:8a:6d:
+                    fc:a7:6a:89:72:af:af:33:d1:fe:78:e3:43:6b:33:
+                    22:f5:4e:e0:c5:c8:b4:f0:2a:82:4c:a7:03:a1:b9:
+                    ca:0a:8b:69:c9:77:55:ea:d4:0d:c7:9b:8d:c1:2c:
+                    d3:47:fe:67:9f:1f:27:f1:aa:45:1e:31:c4:bc:46:
+                    af:a0:cc:9b:37:18:3e:3e:99:4f:9c:46:7d:2c:81:
+                    de:59:72:69:19:2e:2e:8f:d0:3d:6a:f7:09:49:1e:
+                    ac:3f
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            Netscape Comment:
+                Easy-RSA Generated Certificate
+            X509v3 Subject Key Identifier:
+                69:EB:87:03:F4:E1:1B:CA:7D:F8:05:04:BB:78:20:7F:FB:E4:BE:97
+            X509v3 Authority Key Identifier:
+                keyid:17:08:5B:18:E5:22:B2:31:FE:14:61:16:04:92:C4:F4:BB:B8:F2:F2
+                DirName:/C=UA/ST=Kharkiv/L=Kharkiv/O=elastictunnel/OU=elastictunnel.com/CN=elastictunnel CA/name=vpnserver/emailAddress=info@elastictunnel.com
+                serial:73:E0:89:E7:DE:E1:57:F6:28:FF:89:4E:BE:62:C6:7D:A4:07:45:8C
+
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication
+            X509v3 Key Usage:
+                Digital Signature
+            X509v3 Subject Alternative Name:
+                DNS:vpnclient
+    Signature Algorithm: sha256WithRSAEncryption
+         13:bc:79:7d:ea:10:99:00:0f:11:65:d3:19:ce:ad:0a:5c:68:
+         c7:e3:bc:80:eb:60:6a:c9:d0:70:8f:6d:d2:34:f2:40:5e:95:
+         1a:f9:fd:b4:89:44:75:e4:54:4c:89:12:32:bc:05:81:43:22:
+         0a:93:db:f6:df:1c:ae:9c:33:54:db:a1:85:96:7c:c8:52:06:
+         02:e2:bc:c8:89:12:67:3a:2e:96:e1:20:52:ec:8b:a4:f3:0a:
+         2b:48:e4:30:3a:28:47:8a:29:5d:c4:b8:ac:24:3f:65:c8:9e:
+         a9:85:ed:03:c4:79:44:33:5b:ab:5c:92:9c:dc:eb:07:c1:9b:
+         9c:1d:61:f8:c8:e1:f1:1e:89:f7:19:d1:75:e2:ca:2f:e6:20:
+         2f:c9:1d:d4:7e:c8:4f:de:2c:ce:e3:f5:fa:c4:49:e6:f8:03:
+         5f:22:af:5e:a3:78:bb:53:cc:75:ab:37:8a:fb:41:59:a0:28:
+         bb:5f:1d:23:a9:f6:32:1d:54:63:4a:94:64:14:76:9b:6f:da:
+         0d:04:dc:9c:8c:ba:01:87:03:86:4b:c6:3a:65:b8:70:31:da:
+         6f:3c:df:c4:94:c6:18:42:d1:a1:9a:fa:99:a7:d3:de:77:0c:
+         21:0d:60:16:41:f6:59:a3:9b:b5:a9:07:9b:a1:cf:44:34:f8:
+         92:db:f0:5d
+-----BEGIN CERTIFICATE-----
+MIIFgTCCBGmgAwIBAgIBAjANBgkqhkiG9w0BAQsFADCBuzELMAkGA1UEBhMCVUEx
+EDAOBgNVBAgTB0toYXJraXYxEDAOBgNVBAcTB0toYXJraXYxFjAUBgNVBAoTDWVs
+YXN0aWN0dW5uZWwxGjAYBgNVBAsTEWVsYXN0aWN0dW5uZWwuY29tMRkwFwYDVQQD
+ExBlbGFzdGljdHVubmVsIENBMRIwEAYDVQQpEwl2cG5zZXJ2ZXIxJTAjBgkqhkiG
+9w0BCQEWFmluZm9AZWxhc3RpY3R1bm5lbC5jb20wHhcNMTkxMTEyMTMxNTQ5WhcN
+MjkxMTA5MTMxNTQ5WjCBtDELMAkGA1UEBhMCVUExEDAOBgNVBAgTB0toYXJraXYx
+EDAOBgNVBAcTB0toYXJraXYxFjAUBgNVBAoTDWVsYXN0aWN0dW5uZWwxGjAYBgNV
+BAsTEWVsYXN0aWN0dW5uZWwuY29tMRIwEAYDVQQDEwl2cG5jbGllbnQxEjAQBgNV
+BCkTCXZwbnNlcnZlcjElMCMGCSqGSIb3DQEJARYWaW5mb0BlbGFzdGljdHVubmVs
+LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALpu64HHFD3+KIEr
+cXl+ANKCBL1mHCLi3NAYXzq6WW3rLkOO52JMAT8aSCKyE1DgjmT4v29qWU/5mH8a
+4jeCNd6sc2Xvi7E3zT3BksnoQiBcsB+auzDKnYqFKddQwyn8E2LaLZ47xDTPv4Q2
+vBMBJZeRAJDKq/xj6eHbKc4o5/jOdz7hH5xkJXFs5hvif6QVceLurcnsQ0PS5IrP
+5XNsfiUao4pt/KdqiXKvrzPR/njjQ2szIvVO4MXItPAqgkynA6G5ygqLacl3VerU
+DcebjcEs00f+Z58fJ/GqRR4xxLxGr6DMmzcYPj6ZT5xGfSyB3llyaRkuLo/QPWr3
+CUkerD8CAwEAAaOCAZMwggGPMAkGA1UdEwQCMAAwLQYJYIZIAYb4QgENBCAWHkVh
+c3ktUlNBIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4EFgQUaeuHA/ThG8p9
++AUEu3ggf/vkvpcwgfsGA1UdIwSB8zCB8IAUFwhbGOUisjH+FGEWBJLE9Lu48vKh
+gcGkgb4wgbsxCzAJBgNVBAYTAlVBMRAwDgYDVQQIEwdLaGFya2l2MRAwDgYDVQQH
+EwdLaGFya2l2MRYwFAYDVQQKEw1lbGFzdGljdHVubmVsMRowGAYDVQQLExFlbGFz
+dGljdHVubmVsLmNvbTEZMBcGA1UEAxMQZWxhc3RpY3R1bm5lbCBDQTESMBAGA1UE
+KRMJdnBuc2VydmVyMSUwIwYJKoZIhvcNAQkBFhZpbmZvQGVsYXN0aWN0dW5uZWwu
+Y29tghRz4Inn3uFX9ij/iU6+YsZ9pAdFjDATBgNVHSUEDDAKBggrBgEFBQcDAjAL
+BgNVHQ8EBAMCB4AwFAYDVR0RBA0wC4IJdnBuY2xpZW50MA0GCSqGSIb3DQEBCwUA
+A4IBAQATvHl96hCZAA8RZdMZzq0KXGjH47yA62BqydBwj23SNPJAXpUa+f20iUR1
+5FRMiRIyvAWBQyIKk9v23xyunDNU26GFlnzIUgYC4rzIiRJnOi6W4SBS7Iuk8wor
+SOQwOihHiildxLisJD9lyJ6phe0DxHlEM1urXJKc3OsHwZucHWH4yOHxHon3GdF1
+4sov5iAvyR3UfshP3izO4/X6xEnm+ANfIq9eo3i7U8x1qzeK+0FZoCi7Xx0jqfYy
+HVRjSpRkFHabb9oNBNycjLoBhwOGS8Y6ZbhwMdpvPN/ElMYYQtGhmvqZp9Pedwwh
+DWAWQfZZo5u1qQeboc9ENPiS2/Bd
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQC6buuBxxQ9/iiB
+K3F5fgDSggS9Zhwi4tzQGF86ullt6y5DjudiTAE/GkgishNQ4I5k+L9vallP+Zh/
+GuI3gjXerHNl74uxN809wZLJ6EIgXLAfmrswyp2KhSnXUMMp/BNi2i2eO8Q0z7+E
+NrwTASWXkQCQyqv8Y+nh2ynOKOf4znc+4R+cZCVxbOYb4n+kFXHi7q3J7END0uSK
+z+VzbH4lGqOKbfynaolyr68z0f5440NrMyL1TuDFyLTwKoJMpwOhucoKi2nJd1Xq
+1A3Hm43BLNNH/mefHyfxqkUeMcS8Rq+gzJs3GD4+mU+cRn0sgd5ZcmkZLi6P0D1q
+9wlJHqw/AgMBAAECggEABIDPYXgcjg7Ija4t9IBNpsgLM0P3JASUztX33uRHardG
+i80025P4Z7zLx0LD4q0540h630cTVzIxM8jDdBHKGVHTC8BIgIRXiclWMVhR2JRE
+kM7c/KW4PnNO+mtx+16iXT3l4i+RYrEt8BSeYFsjvFB9UgIDO3pyWMlBbkBgsgrI
+BaFVSvDliQJ/YOGVZnYavvbUSTdxlqdhz3BDQGc6ogB/9FUcODdIpHRf1AoBZnbt
+AKoHfEnmRXfk/+uL2pg0DrIhStRIuOJdE1kZNpaxoLzDom1X+lOFpwy60Ith161b
+EjV+Ol2V8QvX/TT/T8WuVuZ/tbGSdTdX44bfkE5V6QKBgQD3ke5mEir4G89/RrhF
+zP1jq29NPUNZ3yDmb+4adk9RxCc0Bq02o7qZ/C2s4gOAY+ZnkBa32Fih0HnXg/rC
+PFSapXbjPIp3AR3Ej5tedQqDATYiXe0fOcJ+Mz9zM6O7Vnri4ZGGGH7Lg+sNVlMi
+fqbEVS3wZk/CeZzOGFN4nHKdSwKBgQDAyA8zG5PS8vYfSr2BeWCiLYor+83Qonn2
+iIPifez5uTpGdyDoFY57jaF/lZfsIte/8eh7jpZrDD7HdXpWwyxNBkHu5a7eN5kh
+K6XqZnkSmrR8+MmTfJGMYV4Q8SdIdUn7EZ2o8++YJUmqFpHBFYS53KwyKI3crUcl
+wxJT1uWYXQKBgDGQvPsgjgvIfZ2Myh3ncZ+/1fPP3SkkHBEmvbP8ldrX+8VVxN4Y
+n6Zur7JaObs9xQZc+b9rCCu1cn9shArZS1L+57ONDmfPCGevHLsnkagy2OS+i1fi
+F4duuThWUWSTZtz/rkP7qX8TdT7hVpmkY70RFLZ5tWRJNtSoWCXgpK3LAoGAbjk0
+r5UB9SfjX0rdhUy/2ppNGQ7Uw4hSUYoGVhaHytSEJEvyrZ+9opj9ELSYc3QMhXur
+4BFLoZMTxfk+ZKMdDkEYq535WKbTT+rj51yFtwRrU9Tvc/tSQMBfBzLKshwVm46b
+5UDr6cLQFobm+U3zYE1yyw7y5YzRVB7vuK3zAiUCgYANQf7424AlLJHxyV6KTykC
+q0cqLEwKzfyo4tcAEIabUSyUhx8bZ74t9ZeBA4aztr0hSXllqXPnNma+nHtPe52U
+qRqKjYJSDZ0+iBihUGhnSZO7kguIE3ZbhE+xIkdN2a8wa4GvZOP3y2RgrqopLgZ6
+Tm0qw9kd/msS9X/ZL0URmg==
+-----END PRIVATE KEY-----
+</key>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+1b1ee2134ec91c40fd0658129ae62fc8
+35b940aec925456d5b14fde10c27b694
+59441671889a4b814934644f5163ad10
+3514fabf08bfc35ee8157210c2ae95fa
+f42463b3492e4f966263512342a50201
+c9ac55058652224421a74f431564ed1f
+388e01844b124637aa89688844a3bc08
+9485a1778137d975808f14f4fa1e0dc6
+ae8d8059d80832d8e9ae8db1ba6575aa
+571a08e975f7aa674e73ddf37afbfcac
+ec4b725c86fe447b44a0849a00b914b7
+32cb411cd6f239cd59a936a099ac017d
+2c3b38e53c1ce188f3c157ca943dfdb7
+de8296711496138873da53fbcd3052fc
+3a5e584417ed052ed8c276de7bd2ebb6
+45abbb3f31ee05a8bdf52df536068f76
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/openvpn/elastictunnel/usa_ny.ovpn
+++ b/openvpn/elastictunnel/usa_ny.ovpn
@@ -1,0 +1,321 @@
+##############################################
+# Sample client-side OpenVPN 2.0 config file #
+# for connecting to multi-client server.     #
+#                                            #
+# This configuration can be used by multiple #
+# clients, however each client should have   #
+# its own cert and key files.                #
+#                                            #
+# On Windows, you might want to rename this  #
+# file so it has a .ovpn extension           #
+##############################################
+
+# Specify that we are a client and that we
+# will be pulling certain config file directives
+# from the server.
+client
+
+# Use the same setting as you are using on
+# the server.
+# On most systems, the VPN will not function
+# unless you partially or fully disable
+# the firewall for the TUN/TAP interface.
+;dev tap
+dev tun
+
+# Windows needs the TAP-Win32 adapter name
+# from the Network Connections panel
+# if you have more than one.  On XP SP2,
+# you may need to disable the firewall
+# for the TAP adapter.
+;dev-node MyTap
+
+# Are we connecting to a TCP or
+# UDP server?  Use the same setting as
+# on the server.
+;proto tcp
+proto tcp
+
+# The hostname/IP and port of the server.
+# You can have multiple remote entries
+# to load balance between the servers.
+remote usa_ny1.elastictunnel.com 443
+remote usa_ny2.elastictunnel.com 443
+remote usa_ny3.elastictunnel.com 443
+remote usa_ny4.elastictunnel.com 443
+
+# Choose a random host from the remote
+# list for load-balancing.  Otherwise
+# try hosts in the order specified.
+;remote-random
+
+# Keep trying indefinitely to resolve the
+# host name of the OpenVPN server.  Very useful
+# on machines which are not permanently connected
+# to the internet such as laptops.
+resolv-retry infinite
+
+# Most clients don't need to bind to
+# a specific local port number.
+nobind
+
+# Downgrade privileges after initialization (non-Windows only)
+;user nobody
+;group nogroup
+
+# Try to preserve some state across restarts.
+persist-key
+persist-tun
+
+# If you are connecting through an
+# HTTP proxy to reach the actual OpenVPN
+# server, put the proxy server/IP and
+# port number here.  See the man page
+# if your proxy server requires
+# authentication.
+;http-proxy-retry # retry on connection failures
+;http-proxy [proxy server] [proxy port #]
+
+# Wireless networks often produce a lot
+# of duplicate packets.  Set this flag
+# to silence duplicate packet warnings.
+;mute-replay-warnings
+
+# SSL/TLS parms.
+# See the server config file for more
+# description.  It's best to use
+# a separate .crt/.key file pair
+# for each client.  A single ca
+# file can be used for all clients.
+#ca ca.crt
+#cert client.crt
+#key client.key
+
+# Verify server certificate by checking that the
+# certicate has the correct key usage set.
+# This is an important precaution to protect against
+# a potential attack discussed here:
+#  http://openvpn.net/howto.html#mitm
+#
+# To use this feature, you will need to generate
+# your server certificates with the keyUsage set to
+#   digitalSignature, keyEncipherment
+# and the extendedKeyUsage to
+#   serverAuth
+# EasyRSA can do this for you.
+remote-cert-tls server
+
+# If a tls-auth key is used on the server
+# then every client must also have the key.
+#tls-auth ta.key 1
+
+# Select a cryptographic cipher.
+# If the cipher option is used on the server
+# then you must also specify it here.
+# Note that v2.4 client/server will automatically
+# negotiate AES-256-GCM in TLS mode.
+# See also the ncp-cipher option in the manpage
+cipher AES-256-CBC
+
+# Enable compression on the VPN link.
+# Don't enable this unless it is also
+# enabled in the server config file.
+#comp-lzo
+
+# Set log file verbosity.
+verb 3
+
+# Silence repeating messages
+;mute 20
+user nobody
+group nogroup
+auth SHA256
+key-direction 1
+auth-user-pass /config/openvpn-credentials.txt
+auth-nocache
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFNzCCBB+gAwIBAgIUc+CJ597hV/Yo/4lOvmLGfaQHRYwwDQYJKoZIhvcNAQEL
+BQAwgbsxCzAJBgNVBAYTAlVBMRAwDgYDVQQIEwdLaGFya2l2MRAwDgYDVQQHEwdL
+aGFya2l2MRYwFAYDVQQKEw1lbGFzdGljdHVubmVsMRowGAYDVQQLExFlbGFzdGlj
+dHVubmVsLmNvbTEZMBcGA1UEAxMQZWxhc3RpY3R1bm5lbCBDQTESMBAGA1UEKRMJ
+dnBuc2VydmVyMSUwIwYJKoZIhvcNAQkBFhZpbmZvQGVsYXN0aWN0dW5uZWwuY29t
+MB4XDTE5MTExMjEzMTM1MFoXDTI5MTEwOTEzMTM1MFowgbsxCzAJBgNVBAYTAlVB
+MRAwDgYDVQQIEwdLaGFya2l2MRAwDgYDVQQHEwdLaGFya2l2MRYwFAYDVQQKEw1l
+bGFzdGljdHVubmVsMRowGAYDVQQLExFlbGFzdGljdHVubmVsLmNvbTEZMBcGA1UE
+AxMQZWxhc3RpY3R1bm5lbCBDQTESMBAGA1UEKRMJdnBuc2VydmVyMSUwIwYJKoZI
+hvcNAQkBFhZpbmZvQGVsYXN0aWN0dW5uZWwuY29tMIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAr3wMwbUIDH/awDltPkRCDiksWZQInj+fktqiaqGO3j/9
+sYkYAZyEra8J32r6PJd+6I993DGtYBTZUOagnMbIA288ruMNdwAeL9XJu517fxzb
+PMaMp1bKbghmDMx5vSyVyOriUhevjj7fp72zQMqjfBXwBU3U8bWBeZIvYKiCUT1n
+jRn4S7iJk3r7F8ah++teqc+qUGBad0/TZ2dub2I/j9pyDCuKTj79Hpl0EvgDrczQ
+kz7asKmQJkrMDJM5tD3wyBrIg23hOHgwy2HuufZW3tG6FtVTyXC0vrUzPWgqdRrY
+AH8De7BF5/VkFevcJDMr6hcs5nfuYwXRHWJHafd16QIDAQABo4IBLzCCASswHQYD
+VR0OBBYEFBcIWxjlIrIx/hRhFgSSxPS7uPLyMIH7BgNVHSMEgfMwgfCAFBcIWxjl
+IrIx/hRhFgSSxPS7uPLyoYHBpIG+MIG7MQswCQYDVQQGEwJVQTEQMA4GA1UECBMH
+S2hhcmtpdjEQMA4GA1UEBxMHS2hhcmtpdjEWMBQGA1UEChMNZWxhc3RpY3R1bm5l
+bDEaMBgGA1UECxMRZWxhc3RpY3R1bm5lbC5jb20xGTAXBgNVBAMTEGVsYXN0aWN0
+dW5uZWwgQ0ExEjAQBgNVBCkTCXZwbnNlcnZlcjElMCMGCSqGSIb3DQEJARYWaW5m
+b0BlbGFzdGljdHVubmVsLmNvbYIUc+CJ597hV/Yo/4lOvmLGfaQHRYwwDAYDVR0T
+BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEASZBfqX7gvSqekHb5NLmzoHaZxvIu
+E8ccMfZDg0htJUh7RTIq8V/ZW1e/D2o8xvbDcio8Z6ukZdVeI789pA29iMZSsdcr
+MfkhVehZ3Niqf5geWmk1VJ680dvnFN4X16d+QB0v0XgKNQzHG9JkOiub9xhTsna0
+FlWBQqUKrQvorHvhWwrhJHV8/eB0mOutRVZ7b61c18E/fWNtzl4w+MTcDbaWl+34
+IgSXwPQVorWedcrgU0PEHQgYOb3fADoEILIqGvODtRqePCKcIoeDzFWuERc1g+tu
+iauWS+ggvMSlRS0Dwpwm/bn9wGCTpjFLcpR/Ie9ankrDompML5x6P4J9dA==
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 2 (0x2)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=UA, ST=Kharkiv, L=Kharkiv, O=elastictunnel, OU=elastictunnel.com, CN=elastictunnel CA/name=vpnserver/emailAddress=info@elastictunnel.com
+        Validity
+            Not Before: Nov 12 13:15:49 2019 GMT
+            Not After : Nov  9 13:15:49 2029 GMT
+        Subject: C=UA, ST=Kharkiv, L=Kharkiv, O=elastictunnel, OU=elastictunnel.com, CN=vpnclient/name=vpnserver/emailAddress=info@elastictunnel.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:ba:6e:eb:81:c7:14:3d:fe:28:81:2b:71:79:7e:
+                    00:d2:82:04:bd:66:1c:22:e2:dc:d0:18:5f:3a:ba:
+                    59:6d:eb:2e:43:8e:e7:62:4c:01:3f:1a:48:22:b2:
+                    13:50:e0:8e:64:f8:bf:6f:6a:59:4f:f9:98:7f:1a:
+                    e2:37:82:35:de:ac:73:65:ef:8b:b1:37:cd:3d:c1:
+                    92:c9:e8:42:20:5c:b0:1f:9a:bb:30:ca:9d:8a:85:
+                    29:d7:50:c3:29:fc:13:62:da:2d:9e:3b:c4:34:cf:
+                    bf:84:36:bc:13:01:25:97:91:00:90:ca:ab:fc:63:
+                    e9:e1:db:29:ce:28:e7:f8:ce:77:3e:e1:1f:9c:64:
+                    25:71:6c:e6:1b:e2:7f:a4:15:71:e2:ee:ad:c9:ec:
+                    43:43:d2:e4:8a:cf:e5:73:6c:7e:25:1a:a3:8a:6d:
+                    fc:a7:6a:89:72:af:af:33:d1:fe:78:e3:43:6b:33:
+                    22:f5:4e:e0:c5:c8:b4:f0:2a:82:4c:a7:03:a1:b9:
+                    ca:0a:8b:69:c9:77:55:ea:d4:0d:c7:9b:8d:c1:2c:
+                    d3:47:fe:67:9f:1f:27:f1:aa:45:1e:31:c4:bc:46:
+                    af:a0:cc:9b:37:18:3e:3e:99:4f:9c:46:7d:2c:81:
+                    de:59:72:69:19:2e:2e:8f:d0:3d:6a:f7:09:49:1e:
+                    ac:3f
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            Netscape Comment:
+                Easy-RSA Generated Certificate
+            X509v3 Subject Key Identifier:
+                69:EB:87:03:F4:E1:1B:CA:7D:F8:05:04:BB:78:20:7F:FB:E4:BE:97
+            X509v3 Authority Key Identifier:
+                keyid:17:08:5B:18:E5:22:B2:31:FE:14:61:16:04:92:C4:F4:BB:B8:F2:F2
+                DirName:/C=UA/ST=Kharkiv/L=Kharkiv/O=elastictunnel/OU=elastictunnel.com/CN=elastictunnel CA/name=vpnserver/emailAddress=info@elastictunnel.com
+                serial:73:E0:89:E7:DE:E1:57:F6:28:FF:89:4E:BE:62:C6:7D:A4:07:45:8C
+
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication
+            X509v3 Key Usage:
+                Digital Signature
+            X509v3 Subject Alternative Name:
+                DNS:vpnclient
+    Signature Algorithm: sha256WithRSAEncryption
+         13:bc:79:7d:ea:10:99:00:0f:11:65:d3:19:ce:ad:0a:5c:68:
+         c7:e3:bc:80:eb:60:6a:c9:d0:70:8f:6d:d2:34:f2:40:5e:95:
+         1a:f9:fd:b4:89:44:75:e4:54:4c:89:12:32:bc:05:81:43:22:
+         0a:93:db:f6:df:1c:ae:9c:33:54:db:a1:85:96:7c:c8:52:06:
+         02:e2:bc:c8:89:12:67:3a:2e:96:e1:20:52:ec:8b:a4:f3:0a:
+         2b:48:e4:30:3a:28:47:8a:29:5d:c4:b8:ac:24:3f:65:c8:9e:
+         a9:85:ed:03:c4:79:44:33:5b:ab:5c:92:9c:dc:eb:07:c1:9b:
+         9c:1d:61:f8:c8:e1:f1:1e:89:f7:19:d1:75:e2:ca:2f:e6:20:
+         2f:c9:1d:d4:7e:c8:4f:de:2c:ce:e3:f5:fa:c4:49:e6:f8:03:
+         5f:22:af:5e:a3:78:bb:53:cc:75:ab:37:8a:fb:41:59:a0:28:
+         bb:5f:1d:23:a9:f6:32:1d:54:63:4a:94:64:14:76:9b:6f:da:
+         0d:04:dc:9c:8c:ba:01:87:03:86:4b:c6:3a:65:b8:70:31:da:
+         6f:3c:df:c4:94:c6:18:42:d1:a1:9a:fa:99:a7:d3:de:77:0c:
+         21:0d:60:16:41:f6:59:a3:9b:b5:a9:07:9b:a1:cf:44:34:f8:
+         92:db:f0:5d
+-----BEGIN CERTIFICATE-----
+MIIFgTCCBGmgAwIBAgIBAjANBgkqhkiG9w0BAQsFADCBuzELMAkGA1UEBhMCVUEx
+EDAOBgNVBAgTB0toYXJraXYxEDAOBgNVBAcTB0toYXJraXYxFjAUBgNVBAoTDWVs
+YXN0aWN0dW5uZWwxGjAYBgNVBAsTEWVsYXN0aWN0dW5uZWwuY29tMRkwFwYDVQQD
+ExBlbGFzdGljdHVubmVsIENBMRIwEAYDVQQpEwl2cG5zZXJ2ZXIxJTAjBgkqhkiG
+9w0BCQEWFmluZm9AZWxhc3RpY3R1bm5lbC5jb20wHhcNMTkxMTEyMTMxNTQ5WhcN
+MjkxMTA5MTMxNTQ5WjCBtDELMAkGA1UEBhMCVUExEDAOBgNVBAgTB0toYXJraXYx
+EDAOBgNVBAcTB0toYXJraXYxFjAUBgNVBAoTDWVsYXN0aWN0dW5uZWwxGjAYBgNV
+BAsTEWVsYXN0aWN0dW5uZWwuY29tMRIwEAYDVQQDEwl2cG5jbGllbnQxEjAQBgNV
+BCkTCXZwbnNlcnZlcjElMCMGCSqGSIb3DQEJARYWaW5mb0BlbGFzdGljdHVubmVs
+LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALpu64HHFD3+KIEr
+cXl+ANKCBL1mHCLi3NAYXzq6WW3rLkOO52JMAT8aSCKyE1DgjmT4v29qWU/5mH8a
+4jeCNd6sc2Xvi7E3zT3BksnoQiBcsB+auzDKnYqFKddQwyn8E2LaLZ47xDTPv4Q2
+vBMBJZeRAJDKq/xj6eHbKc4o5/jOdz7hH5xkJXFs5hvif6QVceLurcnsQ0PS5IrP
+5XNsfiUao4pt/KdqiXKvrzPR/njjQ2szIvVO4MXItPAqgkynA6G5ygqLacl3VerU
+DcebjcEs00f+Z58fJ/GqRR4xxLxGr6DMmzcYPj6ZT5xGfSyB3llyaRkuLo/QPWr3
+CUkerD8CAwEAAaOCAZMwggGPMAkGA1UdEwQCMAAwLQYJYIZIAYb4QgENBCAWHkVh
+c3ktUlNBIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4EFgQUaeuHA/ThG8p9
++AUEu3ggf/vkvpcwgfsGA1UdIwSB8zCB8IAUFwhbGOUisjH+FGEWBJLE9Lu48vKh
+gcGkgb4wgbsxCzAJBgNVBAYTAlVBMRAwDgYDVQQIEwdLaGFya2l2MRAwDgYDVQQH
+EwdLaGFya2l2MRYwFAYDVQQKEw1lbGFzdGljdHVubmVsMRowGAYDVQQLExFlbGFz
+dGljdHVubmVsLmNvbTEZMBcGA1UEAxMQZWxhc3RpY3R1bm5lbCBDQTESMBAGA1UE
+KRMJdnBuc2VydmVyMSUwIwYJKoZIhvcNAQkBFhZpbmZvQGVsYXN0aWN0dW5uZWwu
+Y29tghRz4Inn3uFX9ij/iU6+YsZ9pAdFjDATBgNVHSUEDDAKBggrBgEFBQcDAjAL
+BgNVHQ8EBAMCB4AwFAYDVR0RBA0wC4IJdnBuY2xpZW50MA0GCSqGSIb3DQEBCwUA
+A4IBAQATvHl96hCZAA8RZdMZzq0KXGjH47yA62BqydBwj23SNPJAXpUa+f20iUR1
+5FRMiRIyvAWBQyIKk9v23xyunDNU26GFlnzIUgYC4rzIiRJnOi6W4SBS7Iuk8wor
+SOQwOihHiildxLisJD9lyJ6phe0DxHlEM1urXJKc3OsHwZucHWH4yOHxHon3GdF1
+4sov5iAvyR3UfshP3izO4/X6xEnm+ANfIq9eo3i7U8x1qzeK+0FZoCi7Xx0jqfYy
+HVRjSpRkFHabb9oNBNycjLoBhwOGS8Y6ZbhwMdpvPN/ElMYYQtGhmvqZp9Pedwwh
+DWAWQfZZo5u1qQeboc9ENPiS2/Bd
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQC6buuBxxQ9/iiB
+K3F5fgDSggS9Zhwi4tzQGF86ullt6y5DjudiTAE/GkgishNQ4I5k+L9vallP+Zh/
+GuI3gjXerHNl74uxN809wZLJ6EIgXLAfmrswyp2KhSnXUMMp/BNi2i2eO8Q0z7+E
+NrwTASWXkQCQyqv8Y+nh2ynOKOf4znc+4R+cZCVxbOYb4n+kFXHi7q3J7END0uSK
+z+VzbH4lGqOKbfynaolyr68z0f5440NrMyL1TuDFyLTwKoJMpwOhucoKi2nJd1Xq
+1A3Hm43BLNNH/mefHyfxqkUeMcS8Rq+gzJs3GD4+mU+cRn0sgd5ZcmkZLi6P0D1q
+9wlJHqw/AgMBAAECggEABIDPYXgcjg7Ija4t9IBNpsgLM0P3JASUztX33uRHardG
+i80025P4Z7zLx0LD4q0540h630cTVzIxM8jDdBHKGVHTC8BIgIRXiclWMVhR2JRE
+kM7c/KW4PnNO+mtx+16iXT3l4i+RYrEt8BSeYFsjvFB9UgIDO3pyWMlBbkBgsgrI
+BaFVSvDliQJ/YOGVZnYavvbUSTdxlqdhz3BDQGc6ogB/9FUcODdIpHRf1AoBZnbt
+AKoHfEnmRXfk/+uL2pg0DrIhStRIuOJdE1kZNpaxoLzDom1X+lOFpwy60Ith161b
+EjV+Ol2V8QvX/TT/T8WuVuZ/tbGSdTdX44bfkE5V6QKBgQD3ke5mEir4G89/RrhF
+zP1jq29NPUNZ3yDmb+4adk9RxCc0Bq02o7qZ/C2s4gOAY+ZnkBa32Fih0HnXg/rC
+PFSapXbjPIp3AR3Ej5tedQqDATYiXe0fOcJ+Mz9zM6O7Vnri4ZGGGH7Lg+sNVlMi
+fqbEVS3wZk/CeZzOGFN4nHKdSwKBgQDAyA8zG5PS8vYfSr2BeWCiLYor+83Qonn2
+iIPifez5uTpGdyDoFY57jaF/lZfsIte/8eh7jpZrDD7HdXpWwyxNBkHu5a7eN5kh
+K6XqZnkSmrR8+MmTfJGMYV4Q8SdIdUn7EZ2o8++YJUmqFpHBFYS53KwyKI3crUcl
+wxJT1uWYXQKBgDGQvPsgjgvIfZ2Myh3ncZ+/1fPP3SkkHBEmvbP8ldrX+8VVxN4Y
+n6Zur7JaObs9xQZc+b9rCCu1cn9shArZS1L+57ONDmfPCGevHLsnkagy2OS+i1fi
+F4duuThWUWSTZtz/rkP7qX8TdT7hVpmkY70RFLZ5tWRJNtSoWCXgpK3LAoGAbjk0
+r5UB9SfjX0rdhUy/2ppNGQ7Uw4hSUYoGVhaHytSEJEvyrZ+9opj9ELSYc3QMhXur
+4BFLoZMTxfk+ZKMdDkEYq535WKbTT+rj51yFtwRrU9Tvc/tSQMBfBzLKshwVm46b
+5UDr6cLQFobm+U3zYE1yyw7y5YzRVB7vuK3zAiUCgYANQf7424AlLJHxyV6KTykC
+q0cqLEwKzfyo4tcAEIabUSyUhx8bZ74t9ZeBA4aztr0hSXllqXPnNma+nHtPe52U
+qRqKjYJSDZ0+iBihUGhnSZO7kguIE3ZbhE+xIkdN2a8wa4GvZOP3y2RgrqopLgZ6
+Tm0qw9kd/msS9X/ZL0URmg==
+-----END PRIVATE KEY-----
+</key>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+1b1ee2134ec91c40fd0658129ae62fc8
+35b940aec925456d5b14fde10c27b694
+59441671889a4b814934644f5163ad10
+3514fabf08bfc35ee8157210c2ae95fa
+f42463b3492e4f966263512342a50201
+c9ac55058652224421a74f431564ed1f
+388e01844b124637aa89688844a3bc08
+9485a1778137d975808f14f4fa1e0dc6
+ae8d8059d80832d8e9ae8db1ba6575aa
+571a08e975f7aa674e73ddf37afbfcac
+ec4b725c86fe447b44a0849a00b914b7
+32cb411cd6f239cd59a936a099ac017d
+2c3b38e53c1ce188f3c157ca943dfdb7
+de8296711496138873da53fbcd3052fc
+3a5e584417ed052ed8c276de7bd2ebb6
+45abbb3f31ee05a8bdf52df536068f76
+-----END OpenVPN Static key V1-----
+</tls-auth>

--- a/openvpn/elastictunnel/usa_sf.ovpn
+++ b/openvpn/elastictunnel/usa_sf.ovpn
@@ -1,0 +1,321 @@
+##############################################
+# Sample client-side OpenVPN 2.0 config file #
+# for connecting to multi-client server.     #
+#                                            #
+# This configuration can be used by multiple #
+# clients, however each client should have   #
+# its own cert and key files.                #
+#                                            #
+# On Windows, you might want to rename this  #
+# file so it has a .ovpn extension           #
+##############################################
+
+# Specify that we are a client and that we
+# will be pulling certain config file directives
+# from the server.
+client
+
+# Use the same setting as you are using on
+# the server.
+# On most systems, the VPN will not function
+# unless you partially or fully disable
+# the firewall for the TUN/TAP interface.
+;dev tap
+dev tun
+
+# Windows needs the TAP-Win32 adapter name
+# from the Network Connections panel
+# if you have more than one.  On XP SP2,
+# you may need to disable the firewall
+# for the TAP adapter.
+;dev-node MyTap
+
+# Are we connecting to a TCP or
+# UDP server?  Use the same setting as
+# on the server.
+;proto tcp
+proto tcp
+
+# The hostname/IP and port of the server.
+# You can have multiple remote entries
+# to load balance between the servers.
+remote usa_sf1.elastictunnel.com 443
+remote usa_sf2.elastictunnel.com 443
+remote usa_sf3.elastictunnel.com 443
+remote usa_sf4.elastictunnel.com 443
+
+# Choose a random host from the remote
+# list for load-balancing.  Otherwise
+# try hosts in the order specified.
+;remote-random
+
+# Keep trying indefinitely to resolve the
+# host name of the OpenVPN server.  Very useful
+# on machines which are not permanently connected
+# to the internet such as laptops.
+resolv-retry infinite
+
+# Most clients don't need to bind to
+# a specific local port number.
+nobind
+
+# Downgrade privileges after initialization (non-Windows only)
+;user nobody
+;group nogroup
+
+# Try to preserve some state across restarts.
+persist-key
+persist-tun
+
+# If you are connecting through an
+# HTTP proxy to reach the actual OpenVPN
+# server, put the proxy server/IP and
+# port number here.  See the man page
+# if your proxy server requires
+# authentication.
+;http-proxy-retry # retry on connection failures
+;http-proxy [proxy server] [proxy port #]
+
+# Wireless networks often produce a lot
+# of duplicate packets.  Set this flag
+# to silence duplicate packet warnings.
+;mute-replay-warnings
+
+# SSL/TLS parms.
+# See the server config file for more
+# description.  It's best to use
+# a separate .crt/.key file pair
+# for each client.  A single ca
+# file can be used for all clients.
+#ca ca.crt
+#cert client.crt
+#key client.key
+
+# Verify server certificate by checking that the
+# certicate has the correct key usage set.
+# This is an important precaution to protect against
+# a potential attack discussed here:
+#  http://openvpn.net/howto.html#mitm
+#
+# To use this feature, you will need to generate
+# your server certificates with the keyUsage set to
+#   digitalSignature, keyEncipherment
+# and the extendedKeyUsage to
+#   serverAuth
+# EasyRSA can do this for you.
+remote-cert-tls server
+
+# If a tls-auth key is used on the server
+# then every client must also have the key.
+#tls-auth ta.key 1
+
+# Select a cryptographic cipher.
+# If the cipher option is used on the server
+# then you must also specify it here.
+# Note that v2.4 client/server will automatically
+# negotiate AES-256-GCM in TLS mode.
+# See also the ncp-cipher option in the manpage
+cipher AES-256-CBC
+
+# Enable compression on the VPN link.
+# Don't enable this unless it is also
+# enabled in the server config file.
+#comp-lzo
+
+# Set log file verbosity.
+verb 3
+
+# Silence repeating messages
+;mute 20
+user nobody
+group nogroup
+auth SHA256
+key-direction 1
+auth-user-pass /config/openvpn-credentials.txt
+auth-nocache
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIFNzCCBB+gAwIBAgIUc+CJ597hV/Yo/4lOvmLGfaQHRYwwDQYJKoZIhvcNAQEL
+BQAwgbsxCzAJBgNVBAYTAlVBMRAwDgYDVQQIEwdLaGFya2l2MRAwDgYDVQQHEwdL
+aGFya2l2MRYwFAYDVQQKEw1lbGFzdGljdHVubmVsMRowGAYDVQQLExFlbGFzdGlj
+dHVubmVsLmNvbTEZMBcGA1UEAxMQZWxhc3RpY3R1bm5lbCBDQTESMBAGA1UEKRMJ
+dnBuc2VydmVyMSUwIwYJKoZIhvcNAQkBFhZpbmZvQGVsYXN0aWN0dW5uZWwuY29t
+MB4XDTE5MTExMjEzMTM1MFoXDTI5MTEwOTEzMTM1MFowgbsxCzAJBgNVBAYTAlVB
+MRAwDgYDVQQIEwdLaGFya2l2MRAwDgYDVQQHEwdLaGFya2l2MRYwFAYDVQQKEw1l
+bGFzdGljdHVubmVsMRowGAYDVQQLExFlbGFzdGljdHVubmVsLmNvbTEZMBcGA1UE
+AxMQZWxhc3RpY3R1bm5lbCBDQTESMBAGA1UEKRMJdnBuc2VydmVyMSUwIwYJKoZI
+hvcNAQkBFhZpbmZvQGVsYXN0aWN0dW5uZWwuY29tMIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAr3wMwbUIDH/awDltPkRCDiksWZQInj+fktqiaqGO3j/9
+sYkYAZyEra8J32r6PJd+6I993DGtYBTZUOagnMbIA288ruMNdwAeL9XJu517fxzb
+PMaMp1bKbghmDMx5vSyVyOriUhevjj7fp72zQMqjfBXwBU3U8bWBeZIvYKiCUT1n
+jRn4S7iJk3r7F8ah++teqc+qUGBad0/TZ2dub2I/j9pyDCuKTj79Hpl0EvgDrczQ
+kz7asKmQJkrMDJM5tD3wyBrIg23hOHgwy2HuufZW3tG6FtVTyXC0vrUzPWgqdRrY
+AH8De7BF5/VkFevcJDMr6hcs5nfuYwXRHWJHafd16QIDAQABo4IBLzCCASswHQYD
+VR0OBBYEFBcIWxjlIrIx/hRhFgSSxPS7uPLyMIH7BgNVHSMEgfMwgfCAFBcIWxjl
+IrIx/hRhFgSSxPS7uPLyoYHBpIG+MIG7MQswCQYDVQQGEwJVQTEQMA4GA1UECBMH
+S2hhcmtpdjEQMA4GA1UEBxMHS2hhcmtpdjEWMBQGA1UEChMNZWxhc3RpY3R1bm5l
+bDEaMBgGA1UECxMRZWxhc3RpY3R1bm5lbC5jb20xGTAXBgNVBAMTEGVsYXN0aWN0
+dW5uZWwgQ0ExEjAQBgNVBCkTCXZwbnNlcnZlcjElMCMGCSqGSIb3DQEJARYWaW5m
+b0BlbGFzdGljdHVubmVsLmNvbYIUc+CJ597hV/Yo/4lOvmLGfaQHRYwwDAYDVR0T
+BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEASZBfqX7gvSqekHb5NLmzoHaZxvIu
+E8ccMfZDg0htJUh7RTIq8V/ZW1e/D2o8xvbDcio8Z6ukZdVeI789pA29iMZSsdcr
+MfkhVehZ3Niqf5geWmk1VJ680dvnFN4X16d+QB0v0XgKNQzHG9JkOiub9xhTsna0
+FlWBQqUKrQvorHvhWwrhJHV8/eB0mOutRVZ7b61c18E/fWNtzl4w+MTcDbaWl+34
+IgSXwPQVorWedcrgU0PEHQgYOb3fADoEILIqGvODtRqePCKcIoeDzFWuERc1g+tu
+iauWS+ggvMSlRS0Dwpwm/bn9wGCTpjFLcpR/Ie9ankrDompML5x6P4J9dA==
+-----END CERTIFICATE-----
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 2 (0x2)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=UA, ST=Kharkiv, L=Kharkiv, O=elastictunnel, OU=elastictunnel.com, CN=elastictunnel CA/name=vpnserver/emailAddress=info@elastictunnel.com
+        Validity
+            Not Before: Nov 12 13:15:49 2019 GMT
+            Not After : Nov  9 13:15:49 2029 GMT
+        Subject: C=UA, ST=Kharkiv, L=Kharkiv, O=elastictunnel, OU=elastictunnel.com, CN=vpnclient/name=vpnserver/emailAddress=info@elastictunnel.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:ba:6e:eb:81:c7:14:3d:fe:28:81:2b:71:79:7e:
+                    00:d2:82:04:bd:66:1c:22:e2:dc:d0:18:5f:3a:ba:
+                    59:6d:eb:2e:43:8e:e7:62:4c:01:3f:1a:48:22:b2:
+                    13:50:e0:8e:64:f8:bf:6f:6a:59:4f:f9:98:7f:1a:
+                    e2:37:82:35:de:ac:73:65:ef:8b:b1:37:cd:3d:c1:
+                    92:c9:e8:42:20:5c:b0:1f:9a:bb:30:ca:9d:8a:85:
+                    29:d7:50:c3:29:fc:13:62:da:2d:9e:3b:c4:34:cf:
+                    bf:84:36:bc:13:01:25:97:91:00:90:ca:ab:fc:63:
+                    e9:e1:db:29:ce:28:e7:f8:ce:77:3e:e1:1f:9c:64:
+                    25:71:6c:e6:1b:e2:7f:a4:15:71:e2:ee:ad:c9:ec:
+                    43:43:d2:e4:8a:cf:e5:73:6c:7e:25:1a:a3:8a:6d:
+                    fc:a7:6a:89:72:af:af:33:d1:fe:78:e3:43:6b:33:
+                    22:f5:4e:e0:c5:c8:b4:f0:2a:82:4c:a7:03:a1:b9:
+                    ca:0a:8b:69:c9:77:55:ea:d4:0d:c7:9b:8d:c1:2c:
+                    d3:47:fe:67:9f:1f:27:f1:aa:45:1e:31:c4:bc:46:
+                    af:a0:cc:9b:37:18:3e:3e:99:4f:9c:46:7d:2c:81:
+                    de:59:72:69:19:2e:2e:8f:d0:3d:6a:f7:09:49:1e:
+                    ac:3f
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            Netscape Comment:
+                Easy-RSA Generated Certificate
+            X509v3 Subject Key Identifier:
+                69:EB:87:03:F4:E1:1B:CA:7D:F8:05:04:BB:78:20:7F:FB:E4:BE:97
+            X509v3 Authority Key Identifier:
+                keyid:17:08:5B:18:E5:22:B2:31:FE:14:61:16:04:92:C4:F4:BB:B8:F2:F2
+                DirName:/C=UA/ST=Kharkiv/L=Kharkiv/O=elastictunnel/OU=elastictunnel.com/CN=elastictunnel CA/name=vpnserver/emailAddress=info@elastictunnel.com
+                serial:73:E0:89:E7:DE:E1:57:F6:28:FF:89:4E:BE:62:C6:7D:A4:07:45:8C
+
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication
+            X509v3 Key Usage:
+                Digital Signature
+            X509v3 Subject Alternative Name:
+                DNS:vpnclient
+    Signature Algorithm: sha256WithRSAEncryption
+         13:bc:79:7d:ea:10:99:00:0f:11:65:d3:19:ce:ad:0a:5c:68:
+         c7:e3:bc:80:eb:60:6a:c9:d0:70:8f:6d:d2:34:f2:40:5e:95:
+         1a:f9:fd:b4:89:44:75:e4:54:4c:89:12:32:bc:05:81:43:22:
+         0a:93:db:f6:df:1c:ae:9c:33:54:db:a1:85:96:7c:c8:52:06:
+         02:e2:bc:c8:89:12:67:3a:2e:96:e1:20:52:ec:8b:a4:f3:0a:
+         2b:48:e4:30:3a:28:47:8a:29:5d:c4:b8:ac:24:3f:65:c8:9e:
+         a9:85:ed:03:c4:79:44:33:5b:ab:5c:92:9c:dc:eb:07:c1:9b:
+         9c:1d:61:f8:c8:e1:f1:1e:89:f7:19:d1:75:e2:ca:2f:e6:20:
+         2f:c9:1d:d4:7e:c8:4f:de:2c:ce:e3:f5:fa:c4:49:e6:f8:03:
+         5f:22:af:5e:a3:78:bb:53:cc:75:ab:37:8a:fb:41:59:a0:28:
+         bb:5f:1d:23:a9:f6:32:1d:54:63:4a:94:64:14:76:9b:6f:da:
+         0d:04:dc:9c:8c:ba:01:87:03:86:4b:c6:3a:65:b8:70:31:da:
+         6f:3c:df:c4:94:c6:18:42:d1:a1:9a:fa:99:a7:d3:de:77:0c:
+         21:0d:60:16:41:f6:59:a3:9b:b5:a9:07:9b:a1:cf:44:34:f8:
+         92:db:f0:5d
+-----BEGIN CERTIFICATE-----
+MIIFgTCCBGmgAwIBAgIBAjANBgkqhkiG9w0BAQsFADCBuzELMAkGA1UEBhMCVUEx
+EDAOBgNVBAgTB0toYXJraXYxEDAOBgNVBAcTB0toYXJraXYxFjAUBgNVBAoTDWVs
+YXN0aWN0dW5uZWwxGjAYBgNVBAsTEWVsYXN0aWN0dW5uZWwuY29tMRkwFwYDVQQD
+ExBlbGFzdGljdHVubmVsIENBMRIwEAYDVQQpEwl2cG5zZXJ2ZXIxJTAjBgkqhkiG
+9w0BCQEWFmluZm9AZWxhc3RpY3R1bm5lbC5jb20wHhcNMTkxMTEyMTMxNTQ5WhcN
+MjkxMTA5MTMxNTQ5WjCBtDELMAkGA1UEBhMCVUExEDAOBgNVBAgTB0toYXJraXYx
+EDAOBgNVBAcTB0toYXJraXYxFjAUBgNVBAoTDWVsYXN0aWN0dW5uZWwxGjAYBgNV
+BAsTEWVsYXN0aWN0dW5uZWwuY29tMRIwEAYDVQQDEwl2cG5jbGllbnQxEjAQBgNV
+BCkTCXZwbnNlcnZlcjElMCMGCSqGSIb3DQEJARYWaW5mb0BlbGFzdGljdHVubmVs
+LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALpu64HHFD3+KIEr
+cXl+ANKCBL1mHCLi3NAYXzq6WW3rLkOO52JMAT8aSCKyE1DgjmT4v29qWU/5mH8a
+4jeCNd6sc2Xvi7E3zT3BksnoQiBcsB+auzDKnYqFKddQwyn8E2LaLZ47xDTPv4Q2
+vBMBJZeRAJDKq/xj6eHbKc4o5/jOdz7hH5xkJXFs5hvif6QVceLurcnsQ0PS5IrP
+5XNsfiUao4pt/KdqiXKvrzPR/njjQ2szIvVO4MXItPAqgkynA6G5ygqLacl3VerU
+DcebjcEs00f+Z58fJ/GqRR4xxLxGr6DMmzcYPj6ZT5xGfSyB3llyaRkuLo/QPWr3
+CUkerD8CAwEAAaOCAZMwggGPMAkGA1UdEwQCMAAwLQYJYIZIAYb4QgENBCAWHkVh
+c3ktUlNBIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4EFgQUaeuHA/ThG8p9
++AUEu3ggf/vkvpcwgfsGA1UdIwSB8zCB8IAUFwhbGOUisjH+FGEWBJLE9Lu48vKh
+gcGkgb4wgbsxCzAJBgNVBAYTAlVBMRAwDgYDVQQIEwdLaGFya2l2MRAwDgYDVQQH
+EwdLaGFya2l2MRYwFAYDVQQKEw1lbGFzdGljdHVubmVsMRowGAYDVQQLExFlbGFz
+dGljdHVubmVsLmNvbTEZMBcGA1UEAxMQZWxhc3RpY3R1bm5lbCBDQTESMBAGA1UE
+KRMJdnBuc2VydmVyMSUwIwYJKoZIhvcNAQkBFhZpbmZvQGVsYXN0aWN0dW5uZWwu
+Y29tghRz4Inn3uFX9ij/iU6+YsZ9pAdFjDATBgNVHSUEDDAKBggrBgEFBQcDAjAL
+BgNVHQ8EBAMCB4AwFAYDVR0RBA0wC4IJdnBuY2xpZW50MA0GCSqGSIb3DQEBCwUA
+A4IBAQATvHl96hCZAA8RZdMZzq0KXGjH47yA62BqydBwj23SNPJAXpUa+f20iUR1
+5FRMiRIyvAWBQyIKk9v23xyunDNU26GFlnzIUgYC4rzIiRJnOi6W4SBS7Iuk8wor
+SOQwOihHiildxLisJD9lyJ6phe0DxHlEM1urXJKc3OsHwZucHWH4yOHxHon3GdF1
+4sov5iAvyR3UfshP3izO4/X6xEnm+ANfIq9eo3i7U8x1qzeK+0FZoCi7Xx0jqfYy
+HVRjSpRkFHabb9oNBNycjLoBhwOGS8Y6ZbhwMdpvPN/ElMYYQtGhmvqZp9Pedwwh
+DWAWQfZZo5u1qQeboc9ENPiS2/Bd
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQC6buuBxxQ9/iiB
+K3F5fgDSggS9Zhwi4tzQGF86ullt6y5DjudiTAE/GkgishNQ4I5k+L9vallP+Zh/
+GuI3gjXerHNl74uxN809wZLJ6EIgXLAfmrswyp2KhSnXUMMp/BNi2i2eO8Q0z7+E
+NrwTASWXkQCQyqv8Y+nh2ynOKOf4znc+4R+cZCVxbOYb4n+kFXHi7q3J7END0uSK
+z+VzbH4lGqOKbfynaolyr68z0f5440NrMyL1TuDFyLTwKoJMpwOhucoKi2nJd1Xq
+1A3Hm43BLNNH/mefHyfxqkUeMcS8Rq+gzJs3GD4+mU+cRn0sgd5ZcmkZLi6P0D1q
+9wlJHqw/AgMBAAECggEABIDPYXgcjg7Ija4t9IBNpsgLM0P3JASUztX33uRHardG
+i80025P4Z7zLx0LD4q0540h630cTVzIxM8jDdBHKGVHTC8BIgIRXiclWMVhR2JRE
+kM7c/KW4PnNO+mtx+16iXT3l4i+RYrEt8BSeYFsjvFB9UgIDO3pyWMlBbkBgsgrI
+BaFVSvDliQJ/YOGVZnYavvbUSTdxlqdhz3BDQGc6ogB/9FUcODdIpHRf1AoBZnbt
+AKoHfEnmRXfk/+uL2pg0DrIhStRIuOJdE1kZNpaxoLzDom1X+lOFpwy60Ith161b
+EjV+Ol2V8QvX/TT/T8WuVuZ/tbGSdTdX44bfkE5V6QKBgQD3ke5mEir4G89/RrhF
+zP1jq29NPUNZ3yDmb+4adk9RxCc0Bq02o7qZ/C2s4gOAY+ZnkBa32Fih0HnXg/rC
+PFSapXbjPIp3AR3Ej5tedQqDATYiXe0fOcJ+Mz9zM6O7Vnri4ZGGGH7Lg+sNVlMi
+fqbEVS3wZk/CeZzOGFN4nHKdSwKBgQDAyA8zG5PS8vYfSr2BeWCiLYor+83Qonn2
+iIPifez5uTpGdyDoFY57jaF/lZfsIte/8eh7jpZrDD7HdXpWwyxNBkHu5a7eN5kh
+K6XqZnkSmrR8+MmTfJGMYV4Q8SdIdUn7EZ2o8++YJUmqFpHBFYS53KwyKI3crUcl
+wxJT1uWYXQKBgDGQvPsgjgvIfZ2Myh3ncZ+/1fPP3SkkHBEmvbP8ldrX+8VVxN4Y
+n6Zur7JaObs9xQZc+b9rCCu1cn9shArZS1L+57ONDmfPCGevHLsnkagy2OS+i1fi
+F4duuThWUWSTZtz/rkP7qX8TdT7hVpmkY70RFLZ5tWRJNtSoWCXgpK3LAoGAbjk0
+r5UB9SfjX0rdhUy/2ppNGQ7Uw4hSUYoGVhaHytSEJEvyrZ+9opj9ELSYc3QMhXur
+4BFLoZMTxfk+ZKMdDkEYq535WKbTT+rj51yFtwRrU9Tvc/tSQMBfBzLKshwVm46b
+5UDr6cLQFobm+U3zYE1yyw7y5YzRVB7vuK3zAiUCgYANQf7424AlLJHxyV6KTykC
+q0cqLEwKzfyo4tcAEIabUSyUhx8bZ74t9ZeBA4aztr0hSXllqXPnNma+nHtPe52U
+qRqKjYJSDZ0+iBihUGhnSZO7kguIE3ZbhE+xIkdN2a8wa4GvZOP3y2RgrqopLgZ6
+Tm0qw9kd/msS9X/ZL0URmg==
+-----END PRIVATE KEY-----
+</key>
+<tls-auth>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+1b1ee2134ec91c40fd0658129ae62fc8
+35b940aec925456d5b14fde10c27b694
+59441671889a4b814934644f5163ad10
+3514fabf08bfc35ee8157210c2ae95fa
+f42463b3492e4f966263512342a50201
+c9ac55058652224421a74f431564ed1f
+388e01844b124637aa89688844a3bc08
+9485a1778137d975808f14f4fa1e0dc6
+ae8d8059d80832d8e9ae8db1ba6575aa
+571a08e975f7aa674e73ddf37afbfcac
+ec4b725c86fe447b44a0849a00b914b7
+32cb411cd6f239cd59a936a099ac017d
+2c3b38e53c1ce188f3c157ca943dfdb7
+de8296711496138873da53fbcd3052fc
+3a5e584417ed052ed8c276de7bd2ebb6
+45abbb3f31ee05a8bdf52df536068f76
+-----END OpenVPN Static key V1-----
+</tls-auth>


### PR DESCRIPTION
This PR adds support for [ElasticTunnel VPN Provider](https://elastictunnel.com/).

Supported regions:
- Canada, Toronto. OPENVPN_CONFIG value - `canada_toronto`
- Germany, Frankfurt. OPENVPN_CONFIG value - `germany_frankfurt`
- Netherlands. OPENVPN_CONFIG value - `netherlands`
- UK, London. OPENVPN_CONFIG value - `uk_london`
- Ukraine. OPENVPN_CONFIG value - `ukraine`
- USA, NY. OPENVPN_CONFIG value - `usa_ny`
- USA, SF. OPENVPN_CONFIG value - `usa_sf`

docker run argument values example:
```
docker run --cap-add=NET_ADMIN -d \
...
              -e OPENVPN_PROVIDER=ELASTICTUNNEL \
              -e OPENVPN_CONFIG=canada_toronto \
...
```
