### PR TITLE
Fix build errors with the base Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,14 @@ ARG DOCKERIZE_ARCH=amd64
 ARG DOCKERIZE_VERSION=v0.6.1
 ARG DUMBINIT_VERSION=1.2.2
 
+# Required for omitting the tzdata configuration dialog
+ENV DEBIAN_FRONTEND=noninteractive
+
 # Update, upgrade and install core software
 RUN apt update \
     && apt -y upgrade \
     && apt -y install software-properties-common wget git curl jq \
     && add-apt-repository ppa:transmissionbt/ppa \
-    && wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add - \
-    && echo "deb http://build.openvpn.net/debian/openvpn/stable xenial main" > /etc/apt/sources.list.d/openvpn-aptrepo.list \
     && apt update \
     && apt install -y sudo transmission-cli transmission-common transmission-daemon curl rar unrar zip unzip ufw iputils-ping openvpn bc tzdata \
     python2.7 python2.7-pysqlite2 && ln -sf /usr/bin/python2.7 /usr/bin/python2 \


### PR DESCRIPTION
Related to https://github.com/haugene/docker-transmission-openvpn/pull/939#issuecomment-574247813.

The official OpenVPN sources do not work for some reason, therefore the Ubuntu repositories are taken. Current version there as of this PR is 2.4.4.