### PR TITLE
Added HEALTHCHECK on the Dockerfile.armhf

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -126,7 +126,10 @@ ENV OPENVPN_USERNAME=**None** \
     TRANSMISSION_WEB_HOME= \
     DROP_DEFAULT_ROUTE= \
     WEBPROXY_ENABLED=false \
-    WEBPROXY_PORT=8888
+    WEBPROXY_PORT=8888 \
+    HEALTH_CHECK_HOST=google.com
+
+HEALTHCHECK --interval=5m CMD /etc/scripts/healthcheck.sh
 
 # Expose port and run
 EXPOSE 9091

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -127,7 +127,7 @@ ENV OPENVPN_USERNAME=**None** \
     DROP_DEFAULT_ROUTE= \
     WEBPROXY_ENABLED=false \
     WEBPROXY_PORT=8888 \
-    HEALTH_CHECK_HOST=google222222222222.com
+    HEALTH_CHECK_HOST=google.com
 
 HEALTHCHECK --interval=5m CMD /etc/scripts/healthcheck.sh
 

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -2,7 +2,7 @@ ARG base_image=balenalib/raspberry-pi:stretch
 FROM $base_image
 
 # For building on x86 machines. CircleCI un-comments before building
-#RUN [ "cross-build-start" ]
+RUN [ "cross-build-start" ]
 
 VOLUME /data
 VOLUME /config
@@ -136,4 +136,4 @@ EXPOSE 9091
 CMD ["dumb-init", "/etc/openvpn/start.sh"]
 
 # For building on x86 machines. CircleCI un-comments before building
-#RUN [ "cross-build-end" ]
+RUN [ "cross-build-end" ]

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -2,7 +2,7 @@ ARG base_image=balenalib/raspberry-pi:stretch
 FROM $base_image
 
 # For building on x86 machines. CircleCI un-comments before building
-RUN [ "cross-build-start" ]
+#RUN [ "cross-build-start" ]
 
 VOLUME /data
 VOLUME /config
@@ -127,7 +127,7 @@ ENV OPENVPN_USERNAME=**None** \
     DROP_DEFAULT_ROUTE= \
     WEBPROXY_ENABLED=false \
     WEBPROXY_PORT=8888 \
-    HEALTH_CHECK_HOST=google.com
+    HEALTH_CHECK_HOST=google222222222222.com
 
 HEALTHCHECK --interval=5m CMD /etc/scripts/healthcheck.sh
 
@@ -136,4 +136,4 @@ EXPOSE 9091
 CMD ["dumb-init", "/etc/openvpn/start.sh"]
 
 # For building on x86 machines. CircleCI un-comments before building
-RUN [ "cross-build-end" ]
+#RUN [ "cross-build-end" ]

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -126,9 +126,8 @@ ENV OPENVPN_USERNAME=**None** \
     TRANSMISSION_WEB_HOME= \
     DROP_DEFAULT_ROUTE= \
     WEBPROXY_ENABLED=false \
-    WEBPROXY_PORT=8888 \
-    HEALTH_CHECK_HOST=google.com
-
+    WEBPROXY_PORT=8888 
+    
 HEALTHCHECK --interval=5m CMD /etc/scripts/healthcheck.sh
 
 # Expose port and run

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/haugene/transmission-openvpn.svg)](https://hub.docker.com/r/haugene/transmission-openvpn/)
 [![Join the chat at https://gitter.im/docker-transmission-openvpn/Lobby](https://badges.gitter.im/docker-transmission-openvpn/Lobby.svg)](https://gitter.im/docker-transmission-openvpn/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
+
 ## Quick Start
+
+## WARNING : this fork is only a working fork... always refer to the orginal Haugene repository
 
 This container contains OpenVPN and Transmission with a configuration
 where Transmission is running only when OpenVPN has an active tunnel.


### PR DESCRIPTION
I am using it since fews days, and it is working without any issue (see the screenshot, with one of my container is unhealthy).

It could also be interesting to explain that, according to the Docker Team's 
-  there is no plan to manage a restart, or stop of an unhealthy container.
- an unhealthy docker just run until it it stopped by a command
- this could be"easily done" by a bash command, that invoke a docker ps command to list all unhealthy containers and restart it (i could give you the code if you want)... scheduled in a cron job, you have a 24H/24H running container.

Regards and thank you for you great job.

![Image 8](https://user-images.githubusercontent.com/7581108/72606414-d98e3880-391e-11ea-92af-24fe57749dba.png)
