### PR TITLE
Fix 2.92 memory issue in armhf image

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-ARG base_image=balenalib/raspberry-pi:stretch
+ARG base_image=balenalib/raspberry-pi:buster
 FROM $base_image
 
 # For building on x86 machines. CircleCI un-comments before building

--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -125,10 +125,10 @@ TRANSMISSION_CONTROL_OPTS="--script-security 2 --up-delay --up /etc/openvpn/tunn
 
 ## If we use UFW or the LOCAL_NETWORK we need to grab network config info
 if [[ "${ENABLE_UFW,,}" == "true" ]] || [[ -n "${LOCAL_NETWORK-}" ]]; then
-  eval $(/sbin/ip r l m 0.0.0.0 | awk '{if($5!="tun0"){print "GW="$3"\nINT="$5; exit}}')
+  eval $(/sbin/ip route list match 0.0.0.0 | awk '{if($5!="tun0"){print "GW="$3"\nINT="$5; exit}}')
   ## IF we use UFW_ALLOW_GW_NET along with ENABLE_UFW we need to know what our netmask CIDR is
   if [[ "${ENABLE_UFW,,}" == "true" ]] && [[ "${UFW_ALLOW_GW_NET,,}" == "true" ]]; then
-    eval $(ip r l dev ${INT} | awk '{if($5=="link"){print "GW_CIDR="$1; exit}}')
+    eval $(/sbin/ip route list dev ${INT} | awk '{if($5=="link"){print "GW_CIDR="$1; exit}}')
   fi
 fi
 
@@ -197,7 +197,7 @@ if [[ -n "${LOCAL_NETWORK-}" ]]; then
   if [[ -n "${GW-}" ]] && [[ -n "${INT-}" ]]; then
     for localNet in ${LOCAL_NETWORK//,/ }; do
       echo "adding route to local network ${localNet} via ${GW} dev ${INT}"
-      /sbin/ip r a "${localNet}" via "${GW}" dev "${INT}"
+      /sbin/ip route add "${localNet}" via "${GW}" dev "${INT}"
       if [[ "${ENABLE_UFW,,}" == "true" ]]; then
         ufwAllowPortLong TRANSMISSION_RPC_PORT localNet
         if [[ -n "${UFW_EXTRA_PORTS-}" ]]; then


### PR DESCRIPTION
# Description

The way transmission is packaged in stretch leads to memory issues:
- https://github.com/transmission/transmission/issues/313#issuecomment-446005020
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=865624

The way this manifests for me is that my raspberry pi keeps running out of memory and becomes unresponsive.

The was fixed in buster/transmission-2.94

I've built and pushed this to [my dockerhub repo](https://hub.docker.com/r/fixl/transmission-openvpn/tags) for testing.