### PR TITLE
Add health check to armhf and alpine image

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -29,6 +29,7 @@ RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/ap
 
 ADD openvpn/ /etc/openvpn/
 ADD transmission/ /etc/transmission/
+ADD scripts /etc/scripts/
 
 ENV OPENVPN_USERNAME=**None** \
     OPENVPN_PASSWORD=**None** \
@@ -119,7 +120,10 @@ ENV OPENVPN_USERNAME=**None** \
     TRANSMISSION_WEB_HOME= \
     DROP_DEFAULT_ROUTE= \
     WEBPROXY_ENABLED=false \
-    WEBPROXY_PORT=8888
+    WEBPROXY_PORT=8888 \
+    HEALTH_CHECK_HOST=google.com
+
+HEALTHCHECK --interval=5m CMD /etc/scripts/healthcheck.sh
 
 # Expose port and run
 EXPOSE 9091

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -126,7 +126,10 @@ ENV OPENVPN_USERNAME=**None** \
     TRANSMISSION_WEB_HOME= \
     DROP_DEFAULT_ROUTE= \
     WEBPROXY_ENABLED=false \
-    WEBPROXY_PORT=8888
+    WEBPROXY_PORT=8888 \
+    HEALTH_CHECK_HOST=google.com
+
+HEALTHCHECK --interval=5m CMD /etc/scripts/healthcheck.sh
 
 # Expose port and run
 EXPOSE 9091


### PR DESCRIPTION
# Description

Add `HEALTHCECK`s to armhf and alpine images as well.

This seems like this never made it from [this commit](https://github.com/haugene/docker-transmission-openvpn/commit/0abe1912f4bd41c25ad5b28e04f671b5c6f9238a) to the other two images.

This is similar to #1009