### PR TITLE
Update default.ovpn

### DIFF
--- a/openvpn/fastestvpn/default.ovpn
+++ b/openvpn/fastestvpn/default.ovpn
@@ -1,1 +1,1 @@
-Netherlands-UDP.openvpn
+Netherlands-UDP.ovpn


### PR DESCRIPTION
Choosing default for FASTESTVPN fails due to incorrect file name in file
Netherlands-UDP.openvpn should be Netherlands-UDP.ovpn