### PR TITLE
fix: Quick, dirty hotfix to make NordVPN start.

### DIFF
--- a/docs/nordvpn-script.md
+++ b/docs/nordvpn-script.md
@@ -1,5 +1,7 @@
 ## NORDVPN API
 
+UPDATE: 23/02/2020 - NordVPN have updated their API again, breaking much of the below. Currently the only way to get this part of things working again is to directly set your OPENVPN_CONFIG variable with the exact NordVPN config you wish to use (e.g. OPENVPN_CONFIG=nl127.nordvpn.com.udp1194.ovpn). This should hopefully be fixed once the niceties of https://nordvpn.com/api/server can be unravelled.
+
 The update script is based on the  NordVpn API. The API sends back the best recommended config file based on the filters given.
 
 Available ENV variables in the container to define via the NORDNVPN API the file to use are:
@@ -9,7 +11,7 @@ Available ENV variables in the container to define via the NORDNVPN API the file
 
 the file is then download using the API to find the best server according to the variables, here an albanian, using tcp:
 * selecting server (limit answer to 1): [ANSWER]= https://api.nordvpn.com/v1/servers/recommendations?filters[country_id]=2&filters[servers_technologies][identifier]=openvpn_tcp&filters[servers_group][identifier]=legacy_group_category&limit=1
-* download selected server's config: https://downloads.nordcdn.com/configs/files/ovpn_[NORDVPN_PROTOCOL]/servers/[ANSWER.0.HOSTNAME][] => https://downloads.nordcdn.com/configs/files/ovpn_tcp/servers/al9.nordvpn.com.tcp.ovpn
+* download selected server's config: https://downloads.nordcdn.com/configs/files/ovpn_legacy/servers/[ANSWER.0.HOSTNAME][] => https://downloads.nordcdn.com/configs/files/ovpn_legacy/servers/al9.nordvpn.com.tcp443.ovpn
  
 
 A possible evolution would be to check server's load to select the most available one.

--- a/openvpn/nordvpn/updateConfigs.sh
+++ b/openvpn/nordvpn/updateConfigs.sh
@@ -83,16 +83,10 @@ select_hostname() { #TODO return multiples
     echo ${hostname}
 }
 download_hostname() {
-    #udp ==> https://downloads.nordcdn.com/configs/files/ovpn_udp/servers/nl601.nordvpn.com.udp.ovpn
-    #tcp ==> https://downloads.nordcdn.com/configs/files/ovpn_tcp/servers/nl542.nordvpn.com.tcp.ovpn
+    #udp ==> https://downloads.nordcdn.com/configs/files/ovpn_legacy/servers/al10.nordvpn.com.udp1194.ovpn
+    #tcp ==> https://downloads.nordcdn.com/configs/files/ovpn_legacy/servers/al10.nordvpn.com.tcp443.ovpn
 
-    local nordvpn_cdn="https://downloads.nordcdn.com/configs/files"     
-
-    if [[ ${NORDVPN_PROTOCOL,,} == udp ]]; then
-        nordvpn_cdn="${nordvpn_cdn}/ovpn_udp/servers/"
-    elif [[ ${NORDVPN_PROTOCOL,,} == tcp ]];then
-        nordvpn_cdn="${nordvpn_cdn}/ovpn_tcp/servers/"
-    fi
+    local nordvpn_cdn="https://downloads.nordcdn.com/configs/files/ovpn_legacy/servers/"     
 
     if [[ "$1" == "-d" ]]; then
         nordvpn_cdn=${nordvpn_cdn}${2}
@@ -103,9 +97,9 @@ download_hostname() {
     fi
 
     if [[ ${NORDVPN_PROTOCOL,,} == udp ]]; then
-        nordvpn_cdn="${nordvpn_cdn}.udp.ovpn"
+        nordvpn_cdn="${nordvpn_cdn}.udp1194.ovpn"
     elif [[ ${NORDVPN_PROTOCOL,,} == tcp ]];then
-        nordvpn_cdn="${nordvpn_cdn}.tcp.ovpn"
+        nordvpn_cdn="${nordvpn_cdn}.tcp443.ovpn"
     fi
 
     log "Downloading config: ${ovpnName}"


### PR DESCRIPTION
## Overview

So it looks like NordVPN have gone and changed all their API endpoints again (yay), so half the connection stuff flat out doesn't work any more (they even changed the download endpoint). Have managed to get the container up and running locally with the below changes.

This PR updates the endpoint for the download so that as long as the user provides an OPENVPN_CONFIG, then at least the container can grab that particular config and start up correctly. Current behaviour is that update script will curl the 404 page and then immediately fail (unsurprisingly) when it tries to use it as a ovpn config.

After doing some digging (https://github.com/gjedeer/nordvpn/issues/1), I discovered the https://nordvpn.com/api/server endpoint, but it looks to be very different to what we had before, and will require a bit more work to get up and running. I'll hopefully be able to take a look at it at a later date.

### API Status

As it stands for API endpoints (Used to select optimal profile):
https://api.nordvpn.com/v1/technologies - Still there :tada: 
https://api.nordvpn.com/v1/servers/groups - GONE :warning: 
https://api.nordvpn.com/v1/servers/countries - GONE :warning: 

### Footnote

Apologies, this is my first PR on this project. I did look for a contributing guide, but couldn't find one. If I've gone about this all the wrong way, please let me know I'll fix it. Just be great to have this awesome tool up and running again :smiley: 