### PR TITLE
1195 as opposed to 1194 has better UPnP support.

### DIFF
--- a/openvpn/privatevpn/los-angeles-usa.ovpn
+++ b/openvpn/privatevpn/los-angeles-usa.ovpn
@@ -1,4 +1,4 @@
-remote us-los.pvdata.host 1194 udp
+remote us-los.pvdata.host 1195 udp
 nobind
 dev tun
 


### PR DESCRIPTION
This will allow  transmission to setup forwarder ports. This comes from their tech-support:
```
Please use port 1195 (not 1194) on your OpenVPN setup then connect to the nearest VPN location available on the list below:
Brazil - Sao Paulo, Canada - Toronto, Finland - Espoo, France - Paris, Germany - Frankfurt, Germany - Nuremberg,  India - Chennai, Italy - Milan, Japan - Tokyo, Netherlands - Ams, Norway - Oslo, Poland - Torun, Spain - Madrid, Sweden - Stockholm, Sweden - Kista, Sweden - Gothenburg, Switzerland - Zurich, UK - London, USA - Buffalo, USA - Los Angeles, USA - New York 4
once connected, restart the Torrent client
These servers allow most ports to be forwarded automatically (no need to configure any port settings on your Torrent client).
```