### PR TITLE
Add docker compose example to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ services:
             - OPENVPN_PASSWORD=pass
             - WEBPROXY_ENABLED=false
             - LOCAL_NETWORK=192.168.0.0/16
-        cap-add:
+        cap_add:
             - NET_ADMIN
         logging:
             driver: json-file

--- a/README.md
+++ b/README.md
@@ -27,6 +27,32 @@ $ docker run --cap-add=NET_ADMIN -d \
               haugene/transmission-openvpn
 ```
 
+## Docker Compose
+```
+version: '3.3'
+services:
+    transmission-openvpn:
+        volumes:
+            - '/your/storage/path/:/data'
+            - '/etc/localtime:/etc/localtime:ro'
+        environment:
+            - CREATE_TUN_DEVICE=true
+            - OPENVPN_PROVIDER=PIA
+            - OPENVPN_CONFIG=CA\
+            - OPENVPN_USERNAME=user
+            - OPENVPN_PASSWORD=pass
+            - WEBPROXY_ENABLED=false
+            - LOCAL_NETWORK=192.168.0.0/16
+        logging:
+            driver:
+                - json-file
+            options:
+                max-size: 10m
+        ports:
+            - '9091:9091'
+        image: haugene/transmission-openvpn
+```
+
 ## Documentation
 The full documentation is available at https://haugene.github.io/docker-transmission-openvpn/.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ services:
         environment:
             - CREATE_TUN_DEVICE=true
             - OPENVPN_PROVIDER=PIA
-            - OPENVPN_CONFIG=CA\
+            - OPENVPN_CONFIG=CA Toronto
             - OPENVPN_USERNAME=user
             - OPENVPN_PASSWORD=pass
             - WEBPROXY_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ services:
             - OPENVPN_PASSWORD=pass
             - WEBPROXY_ENABLED=false
             - LOCAL_NETWORK=192.168.0.0/16
+        cap-add:
+            - NET_ADMIN
         logging:
-            driver:
-                - json-file
+            driver: json-file
             options:
                 max-size: 10m
         ports:


### PR DESCRIPTION
`docker-compose` is standard, and following `linuxserver`'s excellent example, including it in the `README.md` enables a far more efficient quick start from Docker Hub. 