### PR TITLE
Fix logging to stdout when using a RUN_AS user

### DIFF
--- a/transmission/start.sh
+++ b/transmission/start.sh
@@ -61,7 +61,7 @@ if [[ "true" = "$DROP_DEFAULT_ROUTE" ]]; then
 fi
 
 if [[ "true" = "$DOCKER_LOG" ]]; then
-  LOGFILE=/proc/1/fd/1
+  LOGFILE=/dev/stdout
 else
   LOGFILE=${TRANSMISSION_HOME}/transmission.log
 fi

--- a/transmission/userSetup.sh
+++ b/transmission/userSetup.sh
@@ -13,6 +13,10 @@ if [ -n "$PUID" ] && [ ! "$(id -u root)" -eq "$PUID" ]; then
         groupmod -o -g "$PGID" ${RUN_AS};
     fi
 
+    if [[ "true" = "$DOCKER_LOG" ]]; then
+      chown ${RUN_AS}:${RUN_AS} /dev/stdout
+    fi
+
     # Make sure directories exist before chown and chmod
     mkdir -p /config \
         ${TRANSMISSION_HOME} \

--- a/transmission/userSetup.sh
+++ b/transmission/userSetup.sh
@@ -6,8 +6,12 @@ RUN_AS=root
 
 if [ -n "$PUID" ] && [ ! "$(id -u root)" -eq "$PUID" ]; then
     RUN_AS=abc
-    if [ ! "$(id -u ${RUN_AS})" -eq "$PUID" ]; then usermod -o -u "$PUID" ${RUN_AS} ; fi
-    if [ ! "$(id -g ${RUN_AS})" -eq "$PGID" ]; then groupmod -o -g "$PGID" ${RUN_AS} ; fi
+    if [ ! "$(id -u ${RUN_AS})" -eq "$PUID" ]; then
+        usermod -o -u "$PUID" ${RUN_AS};
+    fi
+    if [ ! "$(id -g ${RUN_AS})" -eq "$PGID" ]; then
+        groupmod -o -g "$PGID" ${RUN_AS};
+    fi
 
     # Make sure directories exist before chown and chmod
     mkdir -p /config \
@@ -27,18 +31,18 @@ if [ -n "$PUID" ] && [ ! "$(id -u root)" -eq "$PUID" ]; then
         ${TRANSMISSION_HOME}
 
     if [ "$GLOBAL_APPLY_PERMISSIONS" = true ] ; then
-	echo "Setting owner for transmission paths to ${PUID}:${PGID}"
+        echo "Setting owner for transmission paths to ${PUID}:${PGID}"
         chown -R ${RUN_AS}:${RUN_AS} \
             ${TRANSMISSION_DOWNLOAD_DIR} \
             ${TRANSMISSION_INCOMPLETE_DIR} \
             ${TRANSMISSION_WATCH_DIR}
 
-	echo "Setting permission for files (644) and directories (755)"
+        echo "Setting permission for files (644) and directories (755)"
         chmod -R go=rX,u=rwX \
             ${TRANSMISSION_DOWNLOAD_DIR} \
             ${TRANSMISSION_INCOMPLETE_DIR} \
 
-    echo "Setting permission for watch directory (775) and its files (664)"
+        echo "Setting permission for watch directory (775) and its files (664)"
         chmod -R o=rX,ug=rwX \
             ${TRANSMISSION_WATCH_DIR}
     fi


### PR DESCRIPTION
### Before
```
Sun Apr  5 20:54:10 2020 Initialization Sequence Completed
Couldn't (re)open log file "/dev/stdout": Permission denied
```

### After

```
Transmission startup script complete.
Sun Apr  5 20:56:18 2020 Initialization Sequence Completed
[2020-04-05 20:56:19.725] Transmission 2.94 (d8e60ee44f) started (session.c:740)
[2020-04-05 20:56:19.725] RPC Server Adding address to whitelist: 127.0.0.1 (rpc-server.c:971)
```

The `DOCKER_LOG` parameter wasn't working with a `PUID`/`GUID` since `/proc/1/fd/1` is owned by root:root.

I tried chowning that path but it wouldn't persist since it isn't designed for that. `/dev/stdout` is the userspace equivalent and is chownable :)

Couldn't resist and fixed the indenting in the file. Sorry for the noise, for just the fix check 8b70873