### PR TITLE
Mullvad: Updated US configs

### DIFF
--- a/openvpn/mullvad/mullvad_us-az_tcp443.ovpn
+++ b/openvpn/mullvad/mullvad_us-az_tcp443.ovpn
@@ -5,7 +5,7 @@ proto tcp
 
 
 
-remote us-az.mullvad.net 443
+remote us-phx-004.mullvad.net 443
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-az_udp.ovpn
+++ b/openvpn/mullvad/mullvad_us-az_udp.ovpn
@@ -5,7 +5,7 @@ proto udp
 
 
 
-remote us-az.mullvad.net 1301
+remote us-phx-004.mullvad.net 1197
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-ca_tcp443.ovpn
+++ b/openvpn/mullvad/mullvad_us-ca_tcp443.ovpn
@@ -3,10 +3,22 @@ dev tun
 proto tcp
 
 
+remote-random
 
-
-remote us-ca.mullvad.net 443
-
+remote us-lax-002.mullvad.net 443
+remote us-lax-005.mullvad.net 443
+remote us-lax-008.mullvad.net 443
+remote us-lax-009.mullvad.net 443
+remote us-lax-011.mullvad.net 443
+remote us-lax-012.mullvad.net 443
+remote us-lax-013.mullvad.net 443
+remote us-lax-014.mullvad.net 443
+remote us-lax-015.mullvad.net 443
+remote us-lax-017.mullvad.net 443
+remote us-lax-101.mullvad.net 443
+remote us-lax-202.mullvad.net 443
+remote us-lax-301.mullvad.net 443
+remote us-lax-302.mullvad.net 443
 
 cipher AES-256-CBC
 resolv-retry infinite

--- a/openvpn/mullvad/mullvad_us-ca_tcp80.ovpn
+++ b/openvpn/mullvad/mullvad_us-ca_tcp80.ovpn
@@ -4,8 +4,20 @@ proto tcp
 
 
 
-
-remote us-ca.mullvad.net 80
+remote-random
+remote us-lax-005.mullvad.net 80
+remote us-lax-007.mullvad.net 80
+remote us-lax-009.mullvad.net 80
+remote us-lax-010.mullvad.net 80
+remote us-lax-013.mullvad.net 80
+remote us-lax-014.mullvad.net 80
+remote us-lax-015.mullvad.net 80
+remote us-lax-016.mullvad.net 80
+remote us-lax-017.mullvad.net 80
+remote us-lax-101.mullvad.net 80
+remote us-lax-102.mullvad.net 80
+remote us-lax-301.mullvad.net 80
+remote us-lax-302.mullvad.net 80
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-ca_udp.ovpn
+++ b/openvpn/mullvad/mullvad_us-ca_udp.ovpn
@@ -2,13 +2,25 @@ client
 dev tun
 proto udp
 
-
-
-
-remote us-ca.mullvad.net 1301
-
+remote-random
+remote us-lax-002.mullvad.net 1197
+remote us-lax-004.mullvad.net 1197
+remote us-lax-005.mullvad.net 1197
+remote us-lax-006.mullvad.net 1197
+remote us-lax-007.mullvad.net 1197
+remote us-lax-009.mullvad.net 1197
+remote us-lax-011.mullvad.net 1197
+remote us-lax-012.mullvad.net 1197
+remote us-lax-013.mullvad.net 1197
+remote us-lax-015.mullvad.net 1197
+remote us-lax-016.mullvad.net 1197
+remote us-lax-102.mullvad.net 1197
+remote us-lax-202.mullvad.net 1197
+remote us-lax-301.mullvad.net 1197
+remote us-lax-302.mullvad.net 1197
 
 cipher AES-256-CBC
+tls-cipher TLS-DHE-RSA-WITH-AES-256-GCM-SHA384:TLS-DHE-RSA-WITH-AES-256-CBC-SHA
 resolv-retry infinite
 nobind
 persist-key

--- a/openvpn/mullvad/mullvad_us-ca_udp53.ovpn
+++ b/openvpn/mullvad/mullvad_us-ca_udp53.ovpn
@@ -4,8 +4,23 @@ proto udp
 
 
 
-
-remote us-ca.mullvad.net 53
+remote-random
+remote us-lax-002.mullvad.net 53
+remote us-lax-003.mullvad.net 53
+remote us-lax-004.mullvad.net 53
+remote us-lax-005.mullvad.net 53
+remote us-lax-006.mullvad.net 53
+remote us-lax-007.mullvad.net 53
+remote us-lax-008.mullvad.net 53
+remote us-lax-009.mullvad.net 53
+remote us-lax-010.mullvad.net 53
+remote us-lax-011.mullvad.net 53
+remote us-lax-013.mullvad.net 53
+remote us-lax-101.mullvad.net 53
+remote us-lax-102.mullvad.net 53
+remote us-lax-202.mullvad.net 53
+remote us-lax-301.mullvad.net 53
+remote us-lax-302.mullvad.net 53
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-co_tcp443.ovpn
+++ b/openvpn/mullvad/mullvad_us-co_tcp443.ovpn
@@ -5,7 +5,7 @@ proto tcp
 
 
 
-remote us-co.mullvad.net 443
+remote us-den-002.mullvad.net 443
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-co_tcp80.ovpn
+++ b/openvpn/mullvad/mullvad_us-co_tcp80.ovpn
@@ -4,8 +4,9 @@ proto tcp
 
 
 
-
-remote us-co.mullvad.net 80
+remote-random
+remote us-den-001.mullvad.net 80
+remote us-den-002.mullvad.net 80
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-co_udp.ovpn
+++ b/openvpn/mullvad/mullvad_us-co_udp.ovpn
@@ -5,7 +5,7 @@ proto udp
 
 
 
-remote us-co.mullvad.net 1301
+remote us-den-002.mullvad.net 1197
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-co_udp53.ovpn
+++ b/openvpn/mullvad/mullvad_us-co_udp53.ovpn
@@ -5,7 +5,7 @@ proto udp
 
 
 
-remote us-co.mullvad.net 53
+remote us-den-001.mullvad.net 53
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-fl_tcp443.ovpn
+++ b/openvpn/mullvad/mullvad_us-fl_tcp443.ovpn
@@ -4,8 +4,11 @@ proto tcp
 
 
 
-
-remote us-fl.mullvad.net 443
+remote-random
+remote us-mia-002.mullvad.net 443
+remote us-mia-003.mullvad.net 443
+remote us-mia-005.mullvad.net 443
+remote us-mia-101.mullvad.net 443
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-fl_tcp80.ovpn
+++ b/openvpn/mullvad/mullvad_us-fl_tcp80.ovpn
@@ -3,10 +3,14 @@ dev tun
 proto tcp
 
 
+remote-random
 
-
-remote us-fl.mullvad.net 80
-
+remote us-mia-001.mullvad.net 80
+remote us-mia-002.mullvad.net 80
+remote us-mia-003.mullvad.net 80
+remote us-mia-004.mullvad.net 80
+remote us-mia-005.mullvad.net 80
+remote us-mia-101.mullvad.net 80
 
 cipher AES-256-CBC
 resolv-retry infinite

--- a/openvpn/mullvad/mullvad_us-fl_udp.ovpn
+++ b/openvpn/mullvad/mullvad_us-fl_udp.ovpn
@@ -3,10 +3,11 @@ dev tun
 proto udp
 
 
+remote-random
 
-
-remote us-fl.mullvad.net 1301
-
+remote us-mia-002.mullvad.net 1197
+remote us-mia-003.mullvad.net 1197
+remote us-mia-005.mullvad.net 1197
 
 cipher AES-256-CBC
 resolv-retry infinite

--- a/openvpn/mullvad/mullvad_us-fl_udp53.ovpn
+++ b/openvpn/mullvad/mullvad_us-fl_udp53.ovpn
@@ -2,10 +2,12 @@ client
 dev tun
 proto udp
 
+remote-random
 
-
-
-remote us-fl.mullvad.net 53
+remote us-mia-001.mullvad.net 53
+remote us-mia-003.mullvad.net 53
+remote us-mia-004.mullvad.net 53
+remote us-mia-101.mullvad.net 53
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-ga_tcp443.ovpn
+++ b/openvpn/mullvad/mullvad_us-ga_tcp443.ovpn
@@ -5,7 +5,7 @@ proto tcp
 
 
 
-remote us-ga.mullvad.net 443
+remote us-atl-002.mullvad.net 443
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-ga_tcp80.ovpn
+++ b/openvpn/mullvad/mullvad_us-ga_tcp80.ovpn
@@ -5,7 +5,7 @@ proto tcp
 
 
 
-remote us-ga.mullvad.net 80
+remote us-atl-002.mullvad.net 80
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-il_tcp443.ovpn
+++ b/openvpn/mullvad/mullvad_us-il_tcp443.ovpn
@@ -3,10 +3,13 @@ dev tun
 proto tcp
 
 
+remote-random
 
-
-remote us-il.mullvad.net 443
-
+remote us-chi-002.mullvad.net 443
+remote us-chi-004.mullvad.net 443
+remote us-chi-005.mullvad.net 443
+remote us-chi-007.mullvad.net 443
+remote us-chi-010.mullvad.net 443
 
 cipher AES-256-CBC
 resolv-retry infinite

--- a/openvpn/mullvad/mullvad_us-il_tcp80.ovpn
+++ b/openvpn/mullvad/mullvad_us-il_tcp80.ovpn
@@ -4,9 +4,12 @@ proto tcp
 
 
 
-
-remote us-il.mullvad.net 80
-
+remote-random
+remote us-atl-002.mullvad.net 80
+remote us-chi-005.mullvad.net 80
+remote us-chi-008.mullvad.net 80
+remote us-chi-010.mullvad.net 80
+remote us-chi-101.mullvad.net 80
 
 cipher AES-256-CBC
 resolv-retry infinite

--- a/openvpn/mullvad/mullvad_us-il_udp.ovpn
+++ b/openvpn/mullvad/mullvad_us-il_udp.ovpn
@@ -3,10 +3,14 @@ dev tun
 proto udp
 
 
+remote-random
 
-
-remote us-il.mullvad.net 1194
-
+remote us-chi-001.mullvad.net 1197
+remote us-chi-002.mullvad.net 1197
+remote us-chi-003.mullvad.net 1197
+remote us-chi-006.mullvad.net 1197
+remote us-chi-008.mullvad.net 1197
+remote us-chi-010.mullvad.net 1197
 
 cipher AES-256-CBC
 resolv-retry infinite

--- a/openvpn/mullvad/mullvad_us-il_udp53.ovpn
+++ b/openvpn/mullvad/mullvad_us-il_udp53.ovpn
@@ -2,10 +2,14 @@ client
 dev tun
 proto udp
 
-
-
-
-remote us-il.mullvad.net 53
+remote-random
+remote us-chi-001.mullvad.net 53
+remote us-chi-002.mullvad.net 53
+remote us-chi-004.mullvad.net 53
+remote us-chi-005.mullvad.net 53
+remote us-chi-007.mullvad.net 53
+remote us-chi-008.mullvad.net 53
+remote us-chi-101.mullvad.net 53
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-nj_tcp443.ovpn
+++ b/openvpn/mullvad/mullvad_us-nj_tcp443.ovpn
@@ -4,9 +4,12 @@ proto tcp
 
 
 
+remote-random
 
-remote us-nj.mullvad.net 443
-
+remote us-pil-002.mullvad.net 443
+remote us-pil-003.mullvad.net 443
+remote us-uyk-001.mullvad.net 443
+remote us-uyk-002.mullvad.net 443
 
 cipher AES-256-CBC
 resolv-retry infinite

--- a/openvpn/mullvad/mullvad_us-nj_tcp80.ovpn
+++ b/openvpn/mullvad/mullvad_us-nj_tcp80.ovpn
@@ -4,8 +4,14 @@ proto tcp
 
 
 
+remote-random
 
-remote us-nj.mullvad.net 80
+remote us-uyk-001.mullvad.net 80
+remote us-uyk-002.mullvad.net 80
+remote us-pil-001.mullvad.net 80
+remote us-pil-002.mullvad.net 80
+remote us-pil-003.mullvad.net 80
+remote us-sea-004.mullvad.net 80
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-nj_udp.ovpn
+++ b/openvpn/mullvad/mullvad_us-nj_udp.ovpn
@@ -2,11 +2,12 @@ client
 dev tun
 proto udp
 
-
-
-
-remote us-nj.mullvad.net 1197
-
+remote-random
+remote us-uyk-002.mullvad.net 1197
+remote us-uyk-001.mullvad.net 1197
+remote us-pil-001.mullvad.net 1197
+remote us-pil-003.mullvad.net 1197
+remote us-pil-002.mullvad.net 1197
 
 cipher AES-256-CBC
 resolv-retry infinite

--- a/openvpn/mullvad/mullvad_us-nj_udp53.ovpn
+++ b/openvpn/mullvad/mullvad_us-nj_udp53.ovpn
@@ -4,9 +4,9 @@ proto udp
 
 
 
-
-remote us-nj.mullvad.net 53
-
+remote-random
+remote us-pil-003.mullvad.net 53
+remote us-uyk-001.mullvad.net 53
 
 cipher AES-256-CBC
 resolv-retry infinite

--- a/openvpn/mullvad/mullvad_us-ny_tcp443.ovpn
+++ b/openvpn/mullvad/mullvad_us-ny_tcp443.ovpn
@@ -4,8 +4,28 @@ proto tcp
 
 
 
-
-remote us-ny.mullvad.net 443
+remote-random
+remote us-nyc-001.mullvad.net 443
+remote us-nyc-002.mullvad.net 443
+remote us-nyc-003.mullvad.net 443
+remote us-nyc-007.mullvad.net 443
+remote us-nyc-008.mullvad.net 443
+remote us-nyc-009.mullvad.net 443
+remote us-nyc-010.mullvad.net 443
+remote us-nyc-012.mullvad.net 443
+remote us-nyc-014.mullvad.net 443
+remote us-nyc-016.mullvad.net 443
+remote us-nyc-017.mullvad.net 443
+remote us-nyc-019.mullvad.net 443
+remote us-nyc-102.mullvad.net 443
+remote us-nyc-204.mullvad.net 443
+remote us-nyc-208.mullvad.net 443
+remote us-nyc-209.mullvad.net 443
+remote us-nyc-213.mullvad.net 443
+remote us-nyc-216.mullvad.net 443
+remote us-nyc-217.mullvad.net 443
+remote us-nyc-219.mullvad.net 443
+remote us-nyc-220.mullvad.net 443
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-ny_tcp80.ovpn
+++ b/openvpn/mullvad/mullvad_us-ny_tcp80.ovpn
@@ -4,8 +4,35 @@ proto tcp
 
 
 
+remote-random
 
-remote us-ny.mullvad.net 80
+remote us-nyc-002.mullvad.net 80
+remote us-nyc-004.mullvad.net 80
+remote us-nyc-005.mullvad.net 80
+remote us-nyc-007.mullvad.net 80
+remote us-nyc-008.mullvad.net 80
+remote us-nyc-009.mullvad.net 80
+remote us-nyc-011.mullvad.net 80
+remote us-nyc-012.mullvad.net 80
+remote us-nyc-013.mullvad.net 80
+remote us-nyc-014.mullvad.net 80
+remote us-nyc-015.mullvad.net 80
+remote us-nyc-016.mullvad.net 80
+remote us-nyc-019.mullvad.net 80
+remote us-nyc-101.mullvad.net 80
+remote us-nyc-201.mullvad.net 80
+remote us-nyc-202.mullvad.net 80
+remote us-nyc-203.mullvad.net 80
+remote us-nyc-204.mullvad.net 80
+remote us-nyc-205.mullvad.net 80
+remote us-nyc-206.mullvad.net 80
+remote us-nyc-207.mullvad.net 80
+remote us-nyc-210.mullvad.net 80
+remote us-nyc-211.mullvad.net 80
+remote us-nyc-214.mullvad.net 80
+remote us-nyc-217.mullvad.net 80
+remote us-nyc-219.mullvad.net 80
+remote us-nyc-220.mullvad.net 80
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-ny_udp.ovpn
+++ b/openvpn/mullvad/mullvad_us-ny_udp.ovpn
@@ -3,9 +3,29 @@ dev tun
 proto udp
 
 
-
-
-remote us-ny.mullvad.net 1302
+remote-random
+remote us-nyc-003.mullvad.net 1197
+remote us-nyc-004.mullvad.net 1197
+remote us-nyc-005.mullvad.net 1197
+remote us-nyc-007.mullvad.net 1197
+remote us-nyc-008.mullvad.net 1197
+remote us-nyc-011.mullvad.net 1197
+remote us-nyc-014.mullvad.net 1197
+remote us-nyc-015.mullvad.net 1197
+remote us-nyc-017.mullvad.net 1197
+remote us-nyc-201.mullvad.net 1197
+remote us-nyc-203.mullvad.net 1197
+remote us-nyc-204.mullvad.net 1197
+remote us-nyc-205.mullvad.net 1197
+remote us-nyc-206.mullvad.net 1197
+remote us-nyc-208.mullvad.net 1197
+remote us-nyc-209.mullvad.net 1197
+remote us-nyc-210.mullvad.net 1197
+remote us-nyc-211.mullvad.net 1197
+remote us-nyc-213.mullvad.net 1197
+remote us-nyc-216.mullvad.net 1197
+remote us-nyc-217.mullvad.net 1197
+remote us-nyc-219.mullvad.net 1197
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-ny_udp53.ovpn
+++ b/openvpn/mullvad/mullvad_us-ny_udp53.ovpn
@@ -3,9 +3,32 @@ dev tun
 proto udp
 
 
-
-
-remote us-ny.mullvad.net 53
+remote-random
+remote us-nyc-003.mullvad.net 53
+remote us-nyc-004.mullvad.net 53
+remote us-nyc-005.mullvad.net 53
+remote us-nyc-007.mullvad.net 53
+remote us-nyc-008.mullvad.net 53
+remote us-nyc-009.mullvad.net 53
+remote us-nyc-012.mullvad.net 53
+remote us-nyc-015.mullvad.net 53
+remote us-nyc-016.mullvad.net 53
+remote us-nyc-017.mullvad.net 53
+remote us-nyc-019.mullvad.net 53
+remote us-nyc-101.mullvad.net 53
+remote us-nyc-201.mullvad.net 53
+remote us-nyc-202.mullvad.net 53
+remote us-nyc-205.mullvad.net 53
+remote us-nyc-207.mullvad.net 53
+remote us-nyc-208.mullvad.net 53
+remote us-nyc-209.mullvad.net 53
+remote us-nyc-211.mullvad.net 53
+remote us-nyc-213.mullvad.net 53
+remote us-nyc-214.mullvad.net 53
+remote us-nyc-216.mullvad.net 53
+remote us-nyc-217.mullvad.net 53
+remote us-nyc-219.mullvad.net 53
+remote us-nyc-220.mullvad.net 53
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-tx_tcp443.ovpn
+++ b/openvpn/mullvad/mullvad_us-tx_tcp443.ovpn
@@ -4,9 +4,11 @@ proto tcp
 
 
 
+remote-random
 
-remote us-tx.mullvad.net 443
-
+remote us-dal-002.mullvad.net 443
+remote us-dal-003.mullvad.net 443
+remote us-dal-004.mullvad.net 443
 
 cipher AES-256-CBC
 resolv-retry infinite

--- a/openvpn/mullvad/mullvad_us-tx_tcp80.ovpn
+++ b/openvpn/mullvad/mullvad_us-tx_tcp80.ovpn
@@ -5,7 +5,7 @@ proto tcp
 
 
 
-remote us-tx.mullvad.net 80
+remote us-dal-003.mullvad.net 80
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-tx_udp.ovpn
+++ b/openvpn/mullvad/mullvad_us-tx_udp.ovpn
@@ -4,9 +4,10 @@ proto udp
 
 
 
-
-remote us-tx.mullvad.net 1196
-
+remote-random
+remote us-dal-001.mullvad.net 1196
+remote us-dal-004.mullvad.net 1196
+remote us-dal-003.mullvad.net 1196
 
 cipher AES-256-CBC
 resolv-retry infinite

--- a/openvpn/mullvad/mullvad_us-tx_udp53.ovpn
+++ b/openvpn/mullvad/mullvad_us-tx_udp53.ovpn
@@ -2,10 +2,11 @@ client
 dev tun
 proto udp
 
+remote-random
+remote us-dal-003.mullvad.net 53
+remote us-dal-004.mullvad.net 53
+remote us-dal-001.mullvad.net 53
 
-
-
-remote us-tx.mullvad.net 53
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-ut_tcp443.ovpn
+++ b/openvpn/mullvad/mullvad_us-ut_tcp443.ovpn
@@ -3,10 +3,15 @@ dev tun
 proto tcp
 
 
+remote-random
 
-
-remote us-ut.mullvad.net 443
-
+remote us-slc-001.mullvad.net 443
+remote us-slc-003.mullvad.net 443
+remote us-slc-004.mullvad.net 443
+remote us-slc-005.mullvad.net 443
+remote us-slc-006.mullvad.net 443
+remote us-slc-007.mullvad.net 443
+remote us-slc-008.mullvad.net 443
 
 cipher AES-256-CBC
 resolv-retry infinite

--- a/openvpn/mullvad/mullvad_us-ut_tcp80.ovpn
+++ b/openvpn/mullvad/mullvad_us-ut_tcp80.ovpn
@@ -3,9 +3,12 @@ dev tun
 proto tcp
 
 
+remote-random
 
-
-remote us-ut.mullvad.net 80
+remote us-slc-002.mullvad.net 80
+remote us-slc-003.mullvad.net 80
+remote us-slc-005.mullvad.net 80
+remote us-slc-006.mullvad.net 80
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-ut_udp.ovpn
+++ b/openvpn/mullvad/mullvad_us-ut_udp.ovpn
@@ -4,8 +4,14 @@ proto udp
 
 
 
+remote-random
+remote us-slc-003.mullvad.net 1197
+remote us-slc-004.mullvad.net 1197
+remote us-slc-006.mullvad.net 1197
+remote us-slc-007.mullvad.net 1197
+remote us-slc-008.mullvad.net 1197
+remote us-slc-009.mullvad.net 1197
 
-remote us-ut.mullvad.net 1195
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-ut_udp53.ovpn
+++ b/openvpn/mullvad/mullvad_us-ut_udp53.ovpn
@@ -3,9 +3,12 @@ dev tun
 proto udp
 
 
-
-
-remote us-ut.mullvad.net 53
+remote-random
+remote us-slc-002.mullvad.net 53
+remote us-slc-003.mullvad.net 53
+remote us-slc-004.mullvad.net 53
+remote us-slc-006.mullvad.net 53
+remote us-slc-007.mullvad.net 53
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-wa_tcp443.ovpn
+++ b/openvpn/mullvad/mullvad_us-wa_tcp443.ovpn
@@ -3,9 +3,11 @@ dev tun
 proto tcp
 
 
+remote-random
 
-
-remote us-wa.mullvad.net 443
+remote us-sea-001.mullvad.net 443
+remote us-sea-002.mullvad.net 443
+remote us-sea-004.mullvad.net 443
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-wa_tcp80.ovpn
+++ b/openvpn/mullvad/mullvad_us-wa_tcp80.ovpn
@@ -5,7 +5,7 @@ proto tcp
 
 
 
-remote us-wa.mullvad.net 80
+remote us-sea-004.mullvad.net 80
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-wa_udp.ovpn
+++ b/openvpn/mullvad/mullvad_us-wa_udp.ovpn
@@ -3,9 +3,11 @@ dev tun
 proto udp
 
 
-
-
-remote us-wa.mullvad.net 1194
+remote-random
+remote us-sea-001.mullvad.net 1196
+remote us-sea-004.mullvad.net 1196
+remote us-sea-003.mullvad.net 1196
+remote us-sea-002.mullvad.net 1196
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us-wa_udp53.ovpn
+++ b/openvpn/mullvad/mullvad_us-wa_udp53.ovpn
@@ -3,9 +3,11 @@ dev tun
 proto udp
 
 
-
-
-remote us-wa.mullvad.net 53
+remote-random
+remote us-sea-003.mullvad.net 53
+remote us-sea-001.mullvad.net 53
+remote us-sea-002.mullvad.net 53
+remote us-sea-004.mullvad.net 53
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us_tcp443.ovpn
+++ b/openvpn/mullvad/mullvad_us_tcp443.ovpn
@@ -5,7 +5,72 @@ proto tcp
 
 
 
-remote us.mullvad.net 443
+remote-random
+remote us-atl-002.mullvad.net 443
+remote us-chi-002.mullvad.net 443
+remote us-chi-004.mullvad.net 443
+remote us-chi-005.mullvad.net 443
+remote us-chi-007.mullvad.net 443
+remote us-chi-010.mullvad.net 443
+remote us-dal-002.mullvad.net 443
+remote us-dal-003.mullvad.net 443
+remote us-dal-004.mullvad.net 443
+remote us-den-002.mullvad.net 443
+remote us-lax-002.mullvad.net 443
+remote us-lax-005.mullvad.net 443
+remote us-lax-008.mullvad.net 443
+remote us-lax-009.mullvad.net 443
+remote us-lax-011.mullvad.net 443
+remote us-lax-012.mullvad.net 443
+remote us-lax-013.mullvad.net 443
+remote us-lax-014.mullvad.net 443
+remote us-lax-015.mullvad.net 443
+remote us-lax-017.mullvad.net 443
+remote us-lax-101.mullvad.net 443
+remote us-lax-202.mullvad.net 443
+remote us-lax-301.mullvad.net 443
+remote us-lax-302.mullvad.net 443
+remote us-mia-002.mullvad.net 443
+remote us-mia-003.mullvad.net 443
+remote us-mia-005.mullvad.net 443
+remote us-mia-101.mullvad.net 443
+remote us-nyc-001.mullvad.net 443
+remote us-nyc-002.mullvad.net 443
+remote us-nyc-003.mullvad.net 443
+remote us-nyc-007.mullvad.net 443
+remote us-nyc-008.mullvad.net 443
+remote us-nyc-009.mullvad.net 443
+remote us-nyc-010.mullvad.net 443
+remote us-nyc-012.mullvad.net 443
+remote us-nyc-014.mullvad.net 443
+remote us-nyc-016.mullvad.net 443
+remote us-nyc-017.mullvad.net 443
+remote us-nyc-019.mullvad.net 443
+remote us-nyc-102.mullvad.net 443
+remote us-nyc-204.mullvad.net 443
+remote us-nyc-208.mullvad.net 443
+remote us-nyc-209.mullvad.net 443
+remote us-nyc-213.mullvad.net 443
+remote us-nyc-216.mullvad.net 443
+remote us-nyc-217.mullvad.net 443
+remote us-nyc-219.mullvad.net 443
+remote us-nyc-220.mullvad.net 443
+remote us-phx-004.mullvad.net 443
+remote us-pil-002.mullvad.net 443
+remote us-pil-003.mullvad.net 443
+remote us-sea-001.mullvad.net 443
+remote us-sea-002.mullvad.net 443
+remote us-sea-004.mullvad.net 443
+remote us-slc-001.mullvad.net 443
+remote us-slc-003.mullvad.net 443
+remote us-slc-004.mullvad.net 443
+remote us-slc-005.mullvad.net 443
+remote us-slc-006.mullvad.net 443
+remote us-slc-007.mullvad.net 443
+remote us-slc-008.mullvad.net 443
+remote us-uyk-001.mullvad.net 443
+remote us-uyk-002.mullvad.net 443
+
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us_tcp80.ovpn
+++ b/openvpn/mullvad/mullvad_us_tcp80.ovpn
@@ -4,8 +4,71 @@ proto tcp
 
 
 
-
-remote us.mullvad.net 80
+remote-random
+remote us-atl-002.mullvad.net 80
+remote us-chi-005.mullvad.net 80
+remote us-chi-008.mullvad.net 80
+remote us-chi-010.mullvad.net 80
+remote us-chi-101.mullvad.net 80
+remote us-dal-003.mullvad.net 80
+remote us-den-001.mullvad.net 80
+remote us-den-002.mullvad.net 80
+remote us-lax-005.mullvad.net 80
+remote us-lax-007.mullvad.net 80
+remote us-lax-009.mullvad.net 80
+remote us-lax-010.mullvad.net 80
+remote us-lax-013.mullvad.net 80
+remote us-lax-014.mullvad.net 80
+remote us-lax-015.mullvad.net 80
+remote us-lax-016.mullvad.net 80
+remote us-lax-017.mullvad.net 80
+remote us-lax-101.mullvad.net 80
+remote us-lax-102.mullvad.net 80
+remote us-lax-301.mullvad.net 80
+remote us-lax-302.mullvad.net 80
+remote us-mia-001.mullvad.net 80
+remote us-mia-002.mullvad.net 80
+remote us-mia-003.mullvad.net 80
+remote us-mia-004.mullvad.net 80
+remote us-mia-005.mullvad.net 80
+remote us-mia-101.mullvad.net 80
+remote us-nyc-002.mullvad.net 80
+remote us-nyc-004.mullvad.net 80
+remote us-nyc-005.mullvad.net 80
+remote us-nyc-007.mullvad.net 80
+remote us-nyc-008.mullvad.net 80
+remote us-nyc-009.mullvad.net 80
+remote us-nyc-011.mullvad.net 80
+remote us-nyc-012.mullvad.net 80
+remote us-nyc-013.mullvad.net 80
+remote us-nyc-014.mullvad.net 80
+remote us-nyc-015.mullvad.net 80
+remote us-nyc-016.mullvad.net 80
+remote us-nyc-019.mullvad.net 80
+remote us-nyc-101.mullvad.net 80
+remote us-nyc-201.mullvad.net 80
+remote us-nyc-202.mullvad.net 80
+remote us-nyc-203.mullvad.net 80
+remote us-nyc-204.mullvad.net 80
+remote us-nyc-205.mullvad.net 80
+remote us-nyc-206.mullvad.net 80
+remote us-nyc-207.mullvad.net 80
+remote us-nyc-210.mullvad.net 80
+remote us-nyc-211.mullvad.net 80
+remote us-nyc-214.mullvad.net 80
+remote us-nyc-217.mullvad.net 80
+remote us-nyc-219.mullvad.net 80
+remote us-nyc-220.mullvad.net 80
+remote us-pil-001.mullvad.net 80
+remote us-pil-002.mullvad.net 80
+remote us-pil-003.mullvad.net 80
+remote us-sea-004.mullvad.net 80
+remote us-slc-002.mullvad.net 80
+remote us-slc-003.mullvad.net 80
+remote us-slc-005.mullvad.net 80
+remote us-slc-006.mullvad.net 80
+remote us-uyk-001.mullvad.net 80
+remote us-uyk-002.mullvad.net 80
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us_udp.ovpn
+++ b/openvpn/mullvad/mullvad_us_udp.ovpn
@@ -4,8 +4,72 @@ proto udp
 
 
 
+remote-random
+remote us-atl-001.mullvad.net 1197
+remote us-atl-002.mullvad.net 1197
+remote us-atl-003.mullvad.net 1197
+remote us-chi-001.mullvad.net 1197
+remote us-chi-002.mullvad.net 1197
+remote us-chi-003.mullvad.net 1197
+remote us-chi-006.mullvad.net 1197
+remote us-chi-008.mullvad.net 1197
+remote us-chi-010.mullvad.net 1197
+remote us-dal-001.mullvad.net 1197
+remote us-dal-003.mullvad.net 1197
+remote us-dal-004.mullvad.net 1197
+remote us-den-002.mullvad.net 1197
+remote us-lax-002.mullvad.net 1197
+remote us-lax-004.mullvad.net 1197
+remote us-lax-005.mullvad.net 1197
+remote us-lax-006.mullvad.net 1197
+remote us-lax-007.mullvad.net 1197
+remote us-lax-009.mullvad.net 1197
+remote us-lax-011.mullvad.net 1197
+remote us-lax-012.mullvad.net 1197
+remote us-lax-013.mullvad.net 1197
+remote us-lax-015.mullvad.net 1197
+remote us-lax-016.mullvad.net 1197
+remote us-lax-102.mullvad.net 1197
+remote us-lax-202.mullvad.net 1197
+remote us-lax-301.mullvad.net 1197
+remote us-lax-302.mullvad.net 1197
+remote us-mia-002.mullvad.net 1197
+remote us-mia-003.mullvad.net 1197
+remote us-mia-005.mullvad.net 1197
+remote us-nyc-003.mullvad.net 1197
+remote us-nyc-004.mullvad.net 1197
+remote us-nyc-005.mullvad.net 1197
+remote us-nyc-007.mullvad.net 1197
+remote us-nyc-008.mullvad.net 1197
+remote us-nyc-011.mullvad.net 1197
+remote us-nyc-014.mullvad.net 1197
+remote us-nyc-015.mullvad.net 1197
+remote us-nyc-017.mullvad.net 1197
+remote us-nyc-201.mullvad.net 1197
+remote us-nyc-203.mullvad.net 1197
+remote us-nyc-204.mullvad.net 1197
+remote us-nyc-205.mullvad.net 1197
+remote us-nyc-206.mullvad.net 1197
+remote us-nyc-208.mullvad.net 1197
+remote us-nyc-209.mullvad.net 1197
+remote us-nyc-210.mullvad.net 1197
+remote us-nyc-211.mullvad.net 1197
+remote us-nyc-213.mullvad.net 1197
+remote us-nyc-216.mullvad.net 1197
+remote us-nyc-217.mullvad.net 1197
+remote us-nyc-219.mullvad.net 1197
+remote us-phx-004.mullvad.net 1197
+remote us-pil-003.mullvad.net 1197
+remote us-sea-001.mullvad.net 1197
+remote us-sea-002.mullvad.net 1197
+remote us-sea-004.mullvad.net 1197
+remote us-slc-003.mullvad.net 1197
+remote us-slc-004.mullvad.net 1197
+remote us-slc-006.mullvad.net 1197
+remote us-slc-007.mullvad.net 1197
+remote us-slc-008.mullvad.net 1197
+remote us-slc-009.mullvad.net 1197
 
-remote us.mullvad.net 1301
 
 
 cipher AES-256-CBC

--- a/openvpn/mullvad/mullvad_us_udp53.ovpn
+++ b/openvpn/mullvad/mullvad_us_udp53.ovpn
@@ -3,9 +3,72 @@ dev tun
 proto udp
 
 
+remote-random
+remote us-atl-003.mullvad.net 53
+remote us-chi-001.mullvad.net 53
+remote us-chi-002.mullvad.net 53
+remote us-chi-004.mullvad.net 53
+remote us-chi-005.mullvad.net 53
+remote us-chi-007.mullvad.net 53
+remote us-chi-008.mullvad.net 53
+remote us-chi-101.mullvad.net 53
+remote us-dal-004.mullvad.net 53
+remote us-den-001.mullvad.net 53
+remote us-lax-002.mullvad.net 53
+remote us-lax-003.mullvad.net 53
+remote us-lax-004.mullvad.net 53
+remote us-lax-005.mullvad.net 53
+remote us-lax-006.mullvad.net 53
+remote us-lax-007.mullvad.net 53
+remote us-lax-008.mullvad.net 53
+remote us-lax-009.mullvad.net 53
+remote us-lax-010.mullvad.net 53
+remote us-lax-011.mullvad.net 53
+remote us-lax-013.mullvad.net 53
+remote us-lax-101.mullvad.net 53
+remote us-lax-102.mullvad.net 53
+remote us-lax-202.mullvad.net 53
+remote us-lax-301.mullvad.net 53
+remote us-lax-302.mullvad.net 53
+remote us-mia-001.mullvad.net 53
+remote us-mia-003.mullvad.net 53
+remote us-mia-004.mullvad.net 53
+remote us-mia-101.mullvad.net 53
+remote us-nyc-003.mullvad.net 53
+remote us-nyc-004.mullvad.net 53
+remote us-nyc-005.mullvad.net 53
+remote us-nyc-007.mullvad.net 53
+remote us-nyc-008.mullvad.net 53
+remote us-nyc-009.mullvad.net 53
+remote us-nyc-012.mullvad.net 53
+remote us-nyc-015.mullvad.net 53
+remote us-nyc-016.mullvad.net 53
+remote us-nyc-017.mullvad.net 53
+remote us-nyc-019.mullvad.net 53
+remote us-nyc-101.mullvad.net 53
+remote us-nyc-201.mullvad.net 53
+remote us-nyc-202.mullvad.net 53
+remote us-nyc-205.mullvad.net 53
+remote us-nyc-207.mullvad.net 53
+remote us-nyc-208.mullvad.net 53
+remote us-nyc-209.mullvad.net 53
+remote us-nyc-211.mullvad.net 53
+remote us-nyc-213.mullvad.net 53
+remote us-nyc-214.mullvad.net 53
+remote us-nyc-216.mullvad.net 53
+remote us-nyc-217.mullvad.net 53
+remote us-nyc-219.mullvad.net 53
+remote us-nyc-220.mullvad.net 53
+remote us-pil-003.mullvad.net 53
+remote us-sea-003.mullvad.net 53
+remote us-sea-004.mullvad.net 53
+remote us-slc-002.mullvad.net 53
+remote us-slc-003.mullvad.net 53
+remote us-slc-004.mullvad.net 53
+remote us-slc-006.mullvad.net 53
+remote us-slc-007.mullvad.net 53
+remote us-uyk-001.mullvad.net 53
 
-
-remote us.mullvad.net 53
 
 
 cipher AES-256-CBC


### PR DESCRIPTION
Mullvad apparently changed all their openvpn configs to move away from a "load balancer" type host (like `us-ca.mullvad.net`) and instead is using a bunch of hosts in different cities, with numbered hostnames. (like ` us-lax-102.mullvad.net`) and the `remote-random` OpenVPN option.

This PR:
- updates all of the existing US ones that matched an actual state from the older file naming convention e.g California has the new Los Angeles (`lax`) servers
- doesn't touch the other "deprecated" servers since they might still work. (For example some states had no entries in the new files)
- doesn't touch non-US locations (there's a LOT of work to add them, starting from scratch probably would be better, but also a breaking change since it would go from a country to a city (having to change the profile name and thus the docker run command args)

I have tested the us-ca profile in UDP and TCP443 modes, they work great.
