### PR TITLE
Removed space within parsed VPNBOOK password.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ workflows:
 jobs:
   build-ubuntu-image:
     environment:
-      IMAGE_NAME: haugene/transmission-openvpn
+      IMAGE_NAME: colinwebber/transmission-openvpn
     docker:
       - image: circleci/buildpack-deps:stretch
     steps:
@@ -73,7 +73,7 @@ jobs:
 
   build-alpine-image:
     environment:
-      IMAGE_NAME: haugene/transmission-openvpn
+      IMAGE_NAME: colinwebber/transmission-openvpn
     docker:
       - image: circleci/buildpack-deps:stretch
     steps:
@@ -93,7 +93,7 @@ jobs:
 
   build-armhf-image:
     environment:
-      IMAGE_NAME: haugene/transmission-openvpn
+      IMAGE_NAME: colinwebber/transmission-openvpn
     docker:
       - image: circleci/buildpack-deps:stretch
     steps:
@@ -116,7 +116,7 @@ jobs:
 
   build-arm64-image:
     environment:
-      IMAGE_NAME: haugene/transmission-openvpn
+      IMAGE_NAME: colinwebber/transmission-openvpn
     docker:
       - image: circleci/buildpack-deps:stretch
     steps:

--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -76,7 +76,7 @@ then
       -F 'detectOrientation=false' \
       -F 'isTable=false' \
       "https://api.ocr.space/parse/image" -o /tmp/vpnbook_pwd
-    export OPENVPN_PASSWORD=$(cat /tmp/vpnbook_pwd  | awk -F',' '{ print $1 }' | awk -F':' '{print $NF}' | tr -d '"')
+    export OPENVPN_PASSWORD=$(cat /tmp/vpnbook_pwd  | awk -F',' '{ print $1 }' | awk -F':' '{print $NF}' | tr -d '"' | awk '{print $1 $2}')
 fi
 
 if [[ -n "${OPENVPN_CONFIG-}" ]]; then


### PR DESCRIPTION
VPNBOOK password is provided as an image. api.ocr.space/parse/image API erroneously sees a space between certain character combinations. Since passwords generally do not contain spaces, this extra awk expression removes the space.