### PR TITLE
Removed space within parsed VPNBOOK password.

### DIFF
--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -76,7 +76,7 @@ then
       -F 'detectOrientation=false' \
       -F 'isTable=false' \
       "https://api.ocr.space/parse/image" -o /tmp/vpnbook_pwd
-    export OPENVPN_PASSWORD=$(cat /tmp/vpnbook_pwd  | awk -F',' '{ print $1 }' | awk -F':' '{print $NF}' | tr -d '"')
+    export OPENVPN_PASSWORD=$(cat /tmp/vpnbook_pwd  | awk -F',' '{ print $1 }' | awk -F':' '{print $NF}' | tr -d '"' | awk '{print $1 $2}')
 fi
 
 if [[ -n "${OPENVPN_CONFIG-}" ]]; then


### PR DESCRIPTION
VPNBOOK password is provided as a picture/image. The http://api.ocr.space/parse/image service erroneously sees a space between certain character combinations. Since passwords generally do not contain spaces, this extra awk expression removes the space.