### PR TITLE
Updated healthcheck to include openvpn and transmission process

### DIFF
--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+
+#Network check
 # Ping uses both exit codes 1 and 2. Exit code 2 cannot be used for docker health checks,
 # therefore we use this script to catch error code 2
 HOST=${HEALTH_CHECK_HOST}
@@ -18,4 +20,22 @@ then
 fi
 
 echo "Network is up"
+
+#Service check
+#Expected output is 2 for both checks, 1 for process and 1 for grep
+OPENVPN=$(ps | grep 'openvpn --script-security' |wc| awk '{print $1}')
+TRANSMISSION=$(ps | grep 'transmission-daemon' |wc| awk '{print $1}')
+
+if [[ ${OPENVPN} -ne 2 ]]
+then
+	echo "Openvpn process not running"
+	exit 1
+fi
+if [[ ${TRANSMISSION} -ne 2 ]]
+then
+	echo "transmission-daemon process not running"
+	exit 1
+fi
+
+echo "Openvpn and transmission-daemon processes are running"
 exit 0


### PR DESCRIPTION
container will be marked unhealthy when openvpn or transmission process is not running.
it will be up to the user to handle what to do then, (recommend autoheal)
fix #1189 