### PR TITLE
Update healthcheck.sh

### DIFF
--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -23,8 +23,8 @@ echo "Network is up"
 
 #Service check
 #Expected output is 2 for both checks, 1 for process and 1 for grep
-OPENVPN=$(ps | grep 'openvpn --script-security' |wc| awk '{print $1}')
-TRANSMISSION=$(ps | grep 'transmission-daemon' |wc| awk '{print $1}')
+OPENVPN=$(ps aux | grep 'openvpn --script-security' |wc| awk '{print $1}')
+TRANSMISSION=$(ps aux | grep 'transmission-daemon' |wc| awk '{print $1}')
 
 if [[ ${OPENVPN} -ne 2 ]]
 then


### PR DESCRIPTION
`ps` does not return the process without `aux` or at a minimum `ax` as an option:

````
root@7b0bdc3ed3ad:/etc/scripts# ps
  PID TTY          TIME CMD
  225 pts/0    00:00:00 bash
  405 pts/0    00:00:00 ps
root@7b0bdc3ed3ad:/etc/scripts# ps aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  0.0  0.0    208     4 ?        Ss   11:49   0:00 dumb-init /etc/openvpn/start.sh
root         6  4.0  0.0  12144  5028 ?        Ss   11:49   1:33 openvpn --script-security 2 --up-delay --up /etc/openvpn/tunnelUp.sh --down /etc/openvpn/tunnelDown.sh --inactive 3600 --ping 10 --ping-exit 60 --config /etc...
abc         53  1.7  0.0 610152 21328 ?        Ssl  11:49   0:39 /usr/bin/transmission-daemon -g /data --logfile /data/transmission.log
root       225  0.0  0.0   4216  2700 pts/0    Ss   12:08   0:00 bash
root       406  0.0  0.0   5856  1880 pts/0    R+   12:27   0:00 ps aux
````