### PR TITLE
Update OVPN configs (plus a small bonus bugfix)

### DIFF
--- a/openvpn/ovpn/Germany.ovpn
+++ b/openvpn/ovpn/Germany.ovpn
@@ -1,8 +1,8 @@
 client
 dev tun
 proto udp
-remote pool.prd.de.ovpn.se 1194
-remote pool.prd.de.ovpn.se 1195
+remote pool-1.prd.de.ovpn.com 1194
+remote pool-1.prd.de.ovpn.com 1195
 remote-random
 remote-cert-tls server
 cipher AES-256-CBC

--- a/openvpn/ovpn/Sweden.ovpn
+++ b/openvpn/ovpn/Sweden.ovpn
@@ -1,8 +1,8 @@
 client
 dev tun
 proto udp
-remote pool.prd.se.ovpn.se 1194
-remote pool.prd.se.ovpn.se 1195
+remote pool-1.prd.se.ovpn.se 1194
+remote pool-1.prd.se.ovpn.se 1195
 remote-random
 remote-cert-tls server
 cipher AES-256-CBC

--- a/openvpn/ovpn/US.ovpn
+++ b/openvpn/ovpn/US.ovpn
@@ -1,8 +1,8 @@
 client
 dev tun
 proto udp
-remote pool.prd.us.ovpn.com 1194 # resolves to multiple VPN servers in location
-remote pool.prd.us.ovpn.com 1195 # resolves to multiple VPN servers in location
+remote pool-1.prd.us.ovpn.com 1194 # resolves to multiple VPN servers in location
+remote pool-1.prd.us.ovpn.com 1195 # resolves to multiple VPN servers in location
 remote-random
 remote-cert-tls server
 cipher AES-256-CBC

--- a/transmission/userSetup.sh
+++ b/transmission/userSetup.sh
@@ -9,7 +9,7 @@ if [ -n "$PUID" ] && [ ! "$(id -u root)" -eq "$PUID" ]; then
     if [ ! "$(id -u ${RUN_AS})" -eq "$PUID" ]; then
         usermod -o -u "$PUID" ${RUN_AS};
     fi
-    if [ ! "$(id -g ${RUN_AS})" -eq "$PGID" ]; then
+    if [ -n "$PGID" ] && [ ! "$(id -g ${RUN_AS})" -eq "$PGID" ]; then
         groupmod -o -g "$PGID" ${RUN_AS};
     fi
 


### PR DESCRIPTION
OVPN seems to have changed their hostnames, as such,  I've updated the configs to use the new hostnames.

As a bonus, I fixed a logic error in UserSetup that caused an bash error if $PUID was set, but $PGID wasn't.

Fixes #1266
Fixes #1267 
