### PR TITLE
fix slashes in nordvpn cdn urls

### DIFF
--- a/openvpn/nordvpn/updateConfigs.sh
+++ b/openvpn/nordvpn/updateConfigs.sh
@@ -86,7 +86,7 @@ download_hostname() {
     #udp ==> https://downloads.nordcdn.com/configs/files/ovpn_udp/servers/nl601.nordvpn.com.udp.ovpn
     #tcp ==> https://downloads.nordcdn.com/configs/files/ovpn_tcp/servers/nl542.nordvpn.com.tcp.ovpn
 
-    local nordvpn_cdn="https://downloads.nordcdn.com/configs/files"     
+    local nordvpn_cdn="https://downloads.nordcdn.com/configs/files"
 
     if [[ ${NORDVPN_PROTOCOL,,} == udp ]]; then
         nordvpn_cdn="${nordvpn_cdn}/ovpn_udp/servers/"
@@ -95,10 +95,10 @@ download_hostname() {
     fi
 
     if [[ "$1" == "-d" ]]; then
-        nordvpn_cdn=${nordvpn_cdn}${2}
+        nordvpn_cdn=${nordvpn_cdn}/${2}
         ovpnName=default.ovpn
     else
-        nordvpn_cdn=${nordvpn_cdn}${1}
+        nordvpn_cdn=${nordvpn_cdn}/${1}
         ovpnName=${1}.ovpn
     fi
 

--- a/openvpn/nordvpn/updateConfigs.sh
+++ b/openvpn/nordvpn/updateConfigs.sh
@@ -86,13 +86,9 @@ download_hostname() {
     #udp ==> https://downloads.nordcdn.com/configs/files/ovpn_udp/servers/nl601.nordvpn.com.udp.ovpn
     #tcp ==> https://downloads.nordcdn.com/configs/files/ovpn_tcp/servers/nl542.nordvpn.com.tcp.ovpn
 
-    local nordvpn_cdn="https://downloads.nordcdn.com/configs/files"
-
-    if [[ ${NORDVPN_PROTOCOL,,} == udp ]]; then
-        nordvpn_cdn="${nordvpn_cdn}/ovpn_udp/servers/"
-    elif [[ ${NORDVPN_PROTOCOL,,} == tcp ]];then
-        nordvpn_cdn="${nordvpn_cdn}/ovpn_tcp/servers/"
-    fi
+    local nordvpn_cdn="https://downloads.nordcdn.com/configs/files/ovpn_legacy/servers"
+    local udp="udp1194"
+    local tcp="tcp443"
 
     if [[ "$1" == "-d" ]]; then
         nordvpn_cdn=${nordvpn_cdn}/${2}
@@ -103,9 +99,9 @@ download_hostname() {
     fi
 
     if [[ ${NORDVPN_PROTOCOL,,} == udp ]]; then
-        nordvpn_cdn="${nordvpn_cdn}.udp.ovpn"
+        nordvpn_cdn="${nordvpn_cdn}.${udp}.ovpn"
     elif [[ ${NORDVPN_PROTOCOL,,} == tcp ]];then
-        nordvpn_cdn="${nordvpn_cdn}.tcp.ovpn"
+        nordvpn_cdn="${nordvpn_cdn}.${tcp}.ovpn"
     fi
 
     log "Downloading config: ${ovpnName}"


### PR DESCRIPTION
The `nordvpn_cdn` variable is being referenced without slashes in some spots, and with slashes in others. This is leading to the following errors on startup:

```
2020-07-04 19:12:19 Downloading from: https://downloads.nordcdn.com/configs/filesca1091.nordvpn.com
...
2020-07-04 19:12:19 Downloading from: https://downloads.nordcdn.com/configs/filesswitzerland
...
Options error: Unrecognized option or missing or extra parameter(s) in /etc/openvpn/nordvpn/default.ovpn:1: html (2.4.7)
```

Note the missing slashes at the end of the two URLS above^. I assume this returns a 404 html page which is used as the config file and naturally fails to parse.

Updated the variable and its references to prevent this issue.

Additionally, NordVPN has updated their ovpn download url format from `https://downloads.nordcdn.com/configs/files/ca1091.nordvpn.com` to ` https://downloads.nordcdn.com/configs/files/ovpn_legacy/servers/ca1091.nordvpn.com.udp1194.ovpn`. Updated the script to reflect this as well.