### PR TITLE
Adding p7zip and p7zip-full for unzipping on ARM archs

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -10,7 +10,7 @@ VOLUME /config
 # Update packages and install software
 RUN apt-get update \
     && apt-get -y install apt-utils transmission-cli transmission-common transmission-daemon \
-    && apt-get install -y dumb-init unzip openvpn curl ufw git tinyproxy jq bash \
+    && apt-get install -y dumb-init unzip p7zip-full p7zip openvpn curl ufw git tinyproxy jq bash \
     && apt-get -y upgrade \
     && curl -L -o /tmp/release.zip https://github.com/Secretmapper/combustion/archive/release.zip \
     && unzip /tmp/release.zip -d /opt/transmission-ui/ \


### PR DESCRIPTION
Issue at https://github.com/haugene/docker-transmission-openvpn/issues/1283 . Unrar and similar packages are not included in armhf release, thus this package allows us to handle automatic extraction and similar. #1283 