### PR TITLE
Update Dockerfile.alpine

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.12
 
 VOLUME /data
 VOLUME /config


### PR DESCRIPTION
Using Alpine `3.12` to get access to Transmission `3.0.0` 🎉 

https://pkgs.alpinelinux.org/packages?name=transmission&branch=v3.12

https://github.com/transmission/transmission/releases/tag/3.00

I've tested this by upgrading the `3.11.6` APK's inside the container to `3.12` and it runs fine 👍 
- Gives me `Transmission 3.00 (bb6b5a062e)` 😎 
- VPN still connects & logs look tidy 👌