### PR TITLE
Adding support for fetching configs from URL

### DIFF
--- a/openvpn/freevpn/configure-openvpn.sh
+++ b/openvpn/freevpn/configure-openvpn.sh
@@ -17,8 +17,7 @@ OPENVPN_IP=$(curl -s https://freevpn.${DOMAIN}/accounts/ | grep IP |  sed s/"^.*
 # freevpn.me , main server, presents two servers with different address
 # and related password to be used 
 SERVER=${OPENVPN_IP%".freevpn.${DOMAIN}"}
-PASSWORD=$(curl -s https://freevpn.${DOMAIN}/accounts/ | grep Password |  sed s/"^.*Password\:.... "/""/g | sed s/"<.*"/""/g)
-echo "${PASSWORD}" > /etc/freevpn_password
+export OPENVPN_PASSWORD=$(curl -s https://freevpn.${DOMAIN}/accounts/ | grep Password |  sed s/"^.*Password\:.... "/""/g | sed s/"<.*"/""/g)
 
 DIR="/tmp/freevpn"
 TARGET="/etc/openvpn/freevpn"

--- a/openvpn/modify-openvpn-config.sh
+++ b/openvpn/modify-openvpn-config.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo "Modify chosen OpenVPN config for best behaviour in this container"
+
+# Every config modification have its own environemnt variable that can configure the behaviour.
+# Different users, providers or host systems might have specific preferences.
+# But we should try to add sensible defaults, a way to disable it, and alternative implementations as needed.
+
+CONFIG_MOD_USERPASS=${CONFIG_MOD_USERPASS:-"1"}
+
+
+## Option 1 - Change the auth-user-pass line to point to credentials file
+if [[ $CONFIG_MOD_USERPASS == "1" ]]; then
+    echo "Point auth-user-pass option to the username/password file"
+    sed -i "s/auth-user-pass/auth-user-pass \/config\/openvpn-credentials.txt/" "$CHOSEN_OPENVPN_CONFIG"
+fi

--- a/openvpn/nordvpn/configure-openvpn.sh
+++ b/openvpn/nordvpn/configure-openvpn.sh
@@ -1,0 +1,19 @@
+#! /bin/bash
+
+NORDVPN_PROTOCOL=${NORDVPN_PROTOCOL:-UDP}
+export NORDVPN_PROTOCOL
+
+NORDVPN_CATEGORY=${NORDVPN_CATEGORY:-P2P}
+export NORDVPN_CATEGORY
+
+
+if [[ -n $OPENVPN_CONFIG ]]; then
+    tmp_Protocol="${OPENVPN_CONFIG##*.}"
+    export NORDVPN_PROTOCOL=${tmp_Protocol^^}
+    echo "Setting NORDVPN_PROTOCOL to: ${NORDVPN_PROTOCOL}"
+    ${VPN_PROVIDER_HOME}/updateConfigs.sh --openvpn-config
+elif [[ -n $NORDVPN_COUNTRY ]]; then
+    export OPENVPN_CONFIG=$(${VPN_PROVIDER_HOME}/updateConfigs.sh)
+else
+    export OPENVPN_CONFIG=$(${VPN_PROVIDER_HOME}/updateConfigs.sh --get-recommended)
+fi

--- a/openvpn/nordvpn/updateConfigs.sh
+++ b/openvpn/nordvpn/updateConfigs.sh
@@ -110,7 +110,7 @@ download_hostname() {
 
     log "Downloading config: ${ovpnName}"
     log "Downloading from: ${nordvpn_cdn}"
-    curl ${nordvpn_cdn} -o "${ovpnName}"
+    curl -sSL ${nordvpn_cdn} -o "${ovpnName}"
 }
 update_hostname() {
     log "Checking line endings"

--- a/openvpn/vpnbook/configure-openvpn.sh
+++ b/openvpn/vpnbook/configure-openvpn.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+pwd_url=$(curl -s "https://www.vpnbook.com/freevpn" | grep -m2 "Password:" | tail -n1 | cut -d \" -f2)
+curl -s -X POST --header "apikey: 5a64d478-9c89-43d8-88e3-c65de9999580" \
+    -F "url=https://www.vpnbook.com/${pwd_url}" \
+    -F 'language=eng' \
+    -F 'isOverlayRequired=true' \
+    -F 'FileType=.Auto' \
+    -F 'IsCreateSearchablePDF=false' \
+    -F 'isSearchablePdfHideTextLayer=true' \
+    -F 'scale=true' \
+    -F 'detectOrientation=false' \
+    -F 'isTable=false' \
+    "https://api.ocr.space/parse/image" -o /tmp/vpnbook_pwd
+export OPENVPN_PASSWORD=$(cat /tmp/vpnbook_pwd  | awk -F',' '{ print $1 }' | awk -F':' '{print $NF}' | tr -d '"')


### PR DESCRIPTION
This PR restructures the start.sh script a bit. Separating the provider specific scripts from the main script and making it more "pluggable" for new provider specific logic.

Main feature is to accept a URL for config files. This is an alternative to the "manual provider" way of using your own config without coding. Hopefully this will make life easier for those that find it a bit confusing with the volume mounts.

I will update the documentation and enhance this feature a bit more as it will also be an alternative to the frequent provider config updates if more people use it.