### PR TITLE
Update ARM64 image to use Buster as its base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
     environment:
       IMAGE_NAME: haugene/transmission-openvpn
     docker:
-      - image: circleci/buildpack-deps:stretch
+      - image: circleci/buildpack-deps:buster
     steps:
       - checkout
       - setup_remote_docker
@@ -132,7 +132,7 @@ jobs:
             docker build \
               -t $IMAGE_NAME:$IMAGE_TAG \
               -f Dockerfile.armhf \
-              --build-arg base_image=balenalib/raspberrypi3-64:stretch .
+              --build-arg base_image=balenalib/raspberrypi3-64:buster .
       - run:
           name: Login to Docker Hub
           command: echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin


### PR DESCRIPTION
While investigating what seemed like a memory leak in the ARM64 docker image, I realized that the ARM64 docker image still uses Debian Stretch as its base image (limiting it to Transmission 2.92).  This PR corrects that by adjusting the CircleCI build instructions to build against Debian Buster