### PR TITLE
Coerce env var values to expected types by settings.json

### DIFF
--- a/transmission/updateSettings.py
+++ b/transmission/updateSettings.py
@@ -57,6 +57,24 @@ for setting in settings_dict:
     setting_env_name = setting_as_env(setting)
     if setting_env_name in os.environ:
         env_value = os.environ.get(setting_env_name)
+
+        # Coerce env var values to the expected type in settings.json
+        if type(settings_dict[setting]) == bool:
+            env_value = env_value.lower() in ['True', 'true']
+        else:
+            setting_type = type(settings_dict[setting])
+            try:
+                env_value = setting_type(env_value)
+            except ValueError:
+                print(
+                    'Could not coerce {setting_env_name} value {env_value} to expected type {setting_type}'.format(
+                    setting_env_name=setting_env_name,
+                    env_value=env_value,
+                    setting_type=setting_type,
+                    ),
+                )
+                raise
+
         print(
             'Overriding {setting} because {env_name} is set to {value}'.format(
                 setting=setting,

--- a/transmission/updateSettings.py
+++ b/transmission/updateSettings.py
@@ -60,7 +60,7 @@ for setting in settings_dict:
 
         # Coerce env var values to the expected type in settings.json
         if type(settings_dict[setting]) == bool:
-            env_value = env_value.lower() in ['True', 'true']
+            env_value = env_value.lower() == 'true'
         else:
             setting_type = type(settings_dict[setting])
             try:


### PR DESCRIPTION
@haugene 

This addresses a bug introduced by moving from the old settings templating mechanism to using updateSettings.py. 

Previously the settings template controlled the output type when env var values were written to settings.json by having some values quoted and not others. After the move to updateSettings.py that control was lost and all were written as strings. Subsequently Transmission would pick those up and reset them when there's a type mismatch. E.g. a string given instead of an int for max peers "100" would get reset to 0. No torrents would actually download after that. With this change we look at the baseline settings for the expected setting type and coerce the value of the corresponding env var to that type. Tested by building locally and running.