### PR TITLE
Switch to nextgen PIA servers

### DIFF
--- a/openvpn/pia/updateConfigs.sh
+++ b/openvpn/pia/updateConfigs.sh
@@ -9,7 +9,7 @@ cd "${0%/*}"
 find . ! -name '*.sh' -delete
 
 baseURL="https://www.privateinternetaccess.com/openvpn/openvpn"
-extension=".zip"
+extension="-nextgen.zip"
 declare -a configsURLs=(    "" "-strong" "-tcp" "-strong-tcp" "-ip")
 declare -a configsFolders=( "" "strong"  "tcp"  "tcp-strong"  "ip")
 


### PR DESCRIPTION
Official announcement: https://www.privateinternetaccess.com/blog/private-internet-access-legacy-vpn-network-sunset-announcement-30-september

PIA started retiring their "legacy" VPN infrastructure. As far as I could test, the legacy servers stopped working today (or at the very least, *recently*). I patched the running version of the image I had with the "NextGen" version of their OpenVPN configuration files, and it seems to work again.

**Note: they now use the account's username and password instead of the specific PPTP/L2TP username and password**