### PR TITLE
Adds default env TRANSMISSION_RPC_PORT=9091

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ ENV OPENVPN_USERNAME=**None** \
     OPENVPN_PROVIDER=**None** \
     GLOBAL_APPLY_PERMISSIONS=true \
     TRANSMISSION_HOME=/data/transmission-home \
+    TRANSMISSION_RPC_PORT=9091 \
     CREATE_TUN_DEVICE=true \
     ENABLE_UFW=false \
     UFW_ALLOW_GW_NET=false \


### PR DESCRIPTION
If UFW is enabled and no RPC port is provided, the firewall blocks access to the web interface
fixes #1428
fixes #1431