### PR TITLE
Fix getSignature error

### DIFF
--- a/openvpn/pia/update-port.sh
+++ b/openvpn/pia/update-port.sh
@@ -22,7 +22,7 @@ curl_retry=5
 curl_retry_delay=15
 user=$(sed -n 1p /config/openvpn-credentials.txt)
 pass=$(sed -n 2p /config/openvpn-credentials.txt)
-pf_host=$(ip route | head -1 | grep tun | awk '{ print $3 }')
+pf_host=$(ip route | grep tun | grep -v src | head -1 | awk '{ print $3 }')
 ###### Nextgen PIA port forwarding      ##################
    
 get_auth_token () {
@@ -148,7 +148,7 @@ pf_minreuse=$(( 60 * 60 * 24 * 7 ))
 
 pf_remaining=0
 pf_firstrun=1
-vpn_ip=$(ip route | head -1 | grep tun | awk '{ print $3 }')
+vpn_ip=$(ip route | grep tun | grep -v src | head -1 | awk '{ print $3 }')
 pf_host="$vpn_ip"
 
 while true; do


### PR DESCRIPTION
Every time after completion of the initialization sequence, I found the `update-port.sh` script reports errors.

```
STARTING TRANSMISSION
Provider PIA has a script for automatic port forwarding. Will run it now.
If you want to disable this, set environment variable DISABLE_PORT_UPDATER=yes
Transmission startup script complete.
Fri Nov  6 15:10:53 2020 WARNING: OpenVPN was configured to add an IPv6 route ov
er tun0. However, no IPv6 has been configured for this interface, therefore the 
route installation may fail or may not work as expected.
Fri Nov  6 15:10:53 2020 Initialization Sequence Completed



yes: Broken pipe
curl: (3) URL using bad/illegal format or missing URL
Fri Nov  6 15:10:58 PST 2020: getSignature error

the has been a fatal_error
date: invalid date ''
port is 
curl: (3) URL using bad/illegal format or missing URL
Fri Nov  6 15:10:59 PST 2020: bindPort error

the has been a fatal_error
transmission auth required
waiting for transmission to become responsive
transmission became responsive
    ID   Done       Have  ETA           Up    Down  Ratio  Status       Name
Sum:                None               0.0     0.0
setting transmission port to 
localhost:9091/transmission/rpc/ responded: "success"
Checking port...
Error: portTested: http error 400: Bad Request
```
This is caused by an empty `$pf_host` variable, which is generated from this line:
```
pf_host=$(ip route | head -1 | grep tun | awk '{ print $3 }')
```
Executing `ip route` inside the container, I get the following result.
```
0.0.0.0 via 172.17.0.1 dev eth0 
0.0.0.0/1 via 10.1.112.1 dev tun0 
default via 172.17.0.1 dev eth0 
10.1.112.0/24 dev tun0 proto kernel scope link src 10.1.112.12 
128.0.0.0/1 via 10.1.112.1 dev tun0 
156.146.34.2 via 172.17.0.1 dev eth0 
172.17.0.0/16 dev eth0 proto kernel scope link src 172.17.0.2
```
We should catch the first line which is associated with the TUN device and not with the source address, so I tried the following line:
```ip route | grep tun | grep -v src | head -1 | awk '{ print $3 }'```
and got the intended result `10.11.112.1`.

Now the `update-port.sh` script runs flawlessly.
```
STARTING TRANSMISSION
Provider PIA has a script for automatic port forwarding. Will run it now.
If you want to disable this, set environment variable DISABLE_PORT_UPDATER=yes
Transmission startup script complete.
Fri Nov  6 15:12:30 2020 WARNING: OpenVPN was configured to add an IPv6 route over tun0. However, no IPv6 has been configured for this interface, therefore the route installation may fail or may not work as expected.
Fri Nov  6 15:12:30 2020 Initialization Sequence Completed



yes: Broken pipe
port is 28672
the port has been bound to 28672  Fri Nov  6 15:12:35 PST 2020
transmission auth required
waiting for transmission to become responsive
transmission became responsive
    ID   Done       Have  ETA           Up    Down  Ratio  Status       Name
Sum:                None               0.0     0.0
setting transmission port to 28672
localhost:9091/transmission/rpc/ responded: "success"
Checking port...
Port is open: Yes

initial setup complete!
```
