### PR TITLE
set timezone at startup

### DIFF
--- a/openvpn/persistEnvironment.py
+++ b/openvpn/persistEnvironment.py
@@ -21,6 +21,7 @@ wanted_variables = {
     'GLOBAL_APPLY_PERMISSIONS',
     'LOG_TO_STDOUT',
     'DISABLE_PORT_UPDATER',
+    'TZ'
 }
 
 variables_to_persist = {}

--- a/transmission/start.sh
+++ b/transmission/start.sh
@@ -69,10 +69,6 @@ else
   LOGFILE=${TRANSMISSION_HOME}/transmission.log
 fi
 
-if [ ! -z ${TZ} ]; then
-  cp -f "/usr/share/zoneinfo/${TZ}" /etc/localtime && echo "${TZ}" > /etc/timezone
-fi
-
 echo "STARTING TRANSMISSION"
 exec su --preserve-environment ${RUN_AS} -s /bin/bash -c "/usr/bin/transmission-daemon -g ${TRANSMISSION_HOME} --logfile $LOGFILE" &
 

--- a/transmission/start.sh
+++ b/transmission/start.sh
@@ -69,6 +69,10 @@ else
   LOGFILE=${TRANSMISSION_HOME}/transmission.log
 fi
 
+if [ ! -z ${TZ} ]; then
+  cp -f "/usr/share/zoneinfo/${TZ}" /etc/localtime && echo "${TZ}" > /etc/timezone
+fi
+
 echo "STARTING TRANSMISSION"
 exec su --preserve-environment ${RUN_AS} -s /bin/bash -c "/usr/bin/transmission-daemon -g ${TRANSMISSION_HOME} --logfile $LOGFILE" &
 


### PR DESCRIPTION
Setting the TZ environment variable is not respected by transmission log timestamps. It does show the correct time when running `date` interactively in the container, but logs still show UTC timestamps. Various issues have been opened for this and the answer has been to bindmount the host /etc/localtime to force it work. 

Since tzdata is already installed in the image, I hope this is a more elegant solution: copying the timezone data to the correct path before transmission starts. If possible, it'd be ideal to place this at the start of the container so any ufw, openvpn or other logs will also show the correct timestamp, but I was unable to trace where /etc/transmission/start.sh is called from /etc/openvpn/start.sh so this a start.