### PR TITLE
Initial version of route-pre-down script

### DIFF
--- a/scripts/route-pre-down.sh
+++ b/scripts/route-pre-down.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# redirect stdout/stderr to a file
+#exec &>>route-pre-down.log
+
+#Print Date
+NOW=$(date +"%Y-%m-%d %T")
+
+echo "${NOW}: route-pre-down script: Start "
+
+echo "Sending exit signal to transmission."
+
+transmission-remote --exit &
+
+wait
+
+echo "route-pre-down script: Done"
+
+
+

--- a/scripts/route-pre-down.sh
+++ b/scripts/route-pre-down.sh
@@ -8,8 +8,25 @@ NOW=$(date +"%Y-%m-%d %T")
 echo "${NOW}: route-pre-down script: Start "
 
 echo "Sending exit signal to transmission."
+TRANSMISSION_PASSWD_FILE=/config/transmission-credentials.txt
+transmission_username=$(head -1 ${TRANSMISSION_PASSWD_FILE})
+transmission_passwd=$(tail -1 ${TRANSMISSION_PASSWD_FILE})
+transmission_settings_file=${TRANSMISSION_HOME}/settings.json
 
-transmission-remote --exit &
+# Check if transmission remote is set up with authentication
+auth_enabled=$(grep 'rpc-authentication-required\"' "$transmission_settings_file" \
+                   | grep -oE 'true|false')
+
+if [[ "true" = "$auth_enabled" ]]
+  then
+  echo "transmission auth required"
+  myauth="--auth $transmission_username:$transmission_passwd"
+else
+    echo "transmission auth not required"
+    myauth=""
+fi
+
+transmission-remote $myauth --exit &
 
 wait
 


### PR DESCRIPTION
See enhancement request #1362 

Try to gracefully stop transmission when stopping the container.

To enable: add `--route-pre-down /etc/scripts/route-pre-down.sh` to `OPENVPN_OPTS`

According to https://wiki.archlinux.org/index.php/transmission#Transmission_daemon_and_CLI
`pkill -3 transmission-daemon` or `transmission-remote --exit` is the proper way to stop the transmission-daemon, however, during my test `pkill -3` does not work. I was only able to get the exit log with `transmission-remote --exit` 

