### PR TITLE
Add safeguard around transmission shutdown

### DIFF
--- a/transmission/stop.sh
+++ b/transmission/stop.sh
@@ -12,16 +12,21 @@ echo "Sending kill signal (SIGTERM) to transmission-daemon"
 PID=$(pidof transmission-daemon)
 kill $PID
 
-# Give transmission-daemon time to shut down
-for i in {1..10}; do
+# Give transmission-daemon some time to shut down
+TRANSMISSION_TIMEOUT_SEC=10
+TIMEOUT_NITER=$((2 * $TRANSMISSION_TIMEOUT_SEC))
+for i in $(seq $TIMEOUT_NITER); do
     ps -p "$PID" &> /dev/null || break
-    sleep .2
+    [[ $i == 1 ]] && echo "Waiting ${TRANSMISSION_TIMEOUT_SEC}sec for transmission-daemon to die"
+    sleep .5
 done
 
 # Check whether transmission-daemon is still running
 if ! ps -p "$PID" &> /dev/null; then
     echo "Sending kill signal (SIGKILL) to transmission-daemon"
     kill -9 $PID
+else
+    echo "Successfuly closed transmission-daemon"
 fi
 
 # If transmission-post-stop.sh exists, run it

--- a/transmission/stop.sh
+++ b/transmission/stop.sh
@@ -13,7 +13,7 @@ PID=$(pidof transmission-daemon)
 kill $PID
 # Give transmission-daemon time to shut down
 for i in {1..10}; do
-    ps -p $PID &> /dev/null || break
+    ps -p "$PID" &> /dev/null || break
     sleep .2
 done
 

--- a/transmission/stop.sh
+++ b/transmission/stop.sh
@@ -8,14 +8,21 @@ then
    echo "/scripts/transmission-pre-stop.sh returned $?"
 fi
 
-echo "Sending kill signal to transmission-daemon"
+echo "Sending kill signal (SIGTERM) to transmission-daemon"
 PID=$(pidof transmission-daemon)
 kill $PID
+
 # Give transmission-daemon time to shut down
 for i in {1..10}; do
     ps -p "$PID" &> /dev/null || break
     sleep .2
 done
+
+# Check whether transmission-daemon is still running
+if ! ps -p "$PID" &> /dev/null; then
+    echo "Sending kill signal (SIGKILL) to transmission-daemon"
+    kill -9 $PID
+fi
 
 # If transmission-post-stop.sh exists, run it
 if [[ -x /scripts/transmission-post-stop.sh ]]

--- a/transmission/stop.sh
+++ b/transmission/stop.sh
@@ -22,7 +22,7 @@ for i in $(seq $TIMEOUT_NITER); do
 done
 
 # Check whether transmission-daemon is still running
-if ! ps -p "$PID" &> /dev/null; then
+if ps -p "$PID" &> /dev/null; then
     echo "Sending kill signal (SIGKILL) to transmission-daemon"
     kill -9 $PID
 else


### PR DESCRIPTION
This is really a nitpicking PR, but it doesn't hurt IMO.

Commit 0ee67b1... sanitizes the `ps -p` call.
Commit e9e399c... ensures `transmission-daemon` is indeed killed after the 2 second timeout which was already present.

On my setup, exiting a normally running daemon is instant; I don't know what could make it hang for more than 2 seconds (I/O in the case of remote file systems transparently given to the container ?) but it might make sense to either increase it or to set it as an environment variable since it is killed using `kill -9`.