### PR TITLE
Apply Transmission umask setting to download directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ ENV OPENVPN_USERNAME=**None** \
     TRANSMISSION_DOWNLOAD_DIR=/data/completed \
     TRANSMISSION_INCOMPLETE_DIR=/data/incomplete \
     TRANSMISSION_WATCH_DIR=/data/watch \
+    TRANSMISSION_UMASK=2 \
     CREATE_TUN_DEVICE=true \
     ENABLE_UFW=false \
     UFW_ALLOW_GW_NET=false \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,6 @@ ENV OPENVPN_USERNAME=**None** \
     TRANSMISSION_DOWNLOAD_DIR=/data/completed \
     TRANSMISSION_INCOMPLETE_DIR=/data/incomplete \
     TRANSMISSION_WATCH_DIR=/data/watch \
-    TRANSMISSION_UMASK=2 \
     CREATE_TUN_DEVICE=true \
     ENABLE_UFW=false \
     UFW_ALLOW_GW_NET=false \

--- a/transmission/userSetup.sh
+++ b/transmission/userSetup.sh
@@ -42,7 +42,7 @@ if [ -n "$PUID" ] && [ ! "$(id -u root)" -eq "$PUID" ]; then
             ${TRANSMISSION_WATCH_DIR}
 
         echo "Setting permissions for download and incomplete directories"
-        TRANSMISSION_UMASK_OCTAL=$(printf '%03g' $(printf '%o\n' $(jq .umask /config/settings.json)))
+        TRANSMISSION_UMASK_OCTAL=$(printf '%03g' $(printf '%o\n' $(jq .umask ${TRANSMISSION_HOME}/settings.json)))
         DIR_PERMS=$(printf '%o\n' $((0777 & ~TRANSMISSION_UMASK_OCTAL)))
         FILE_PERMS=$(printf '%o\n' $((0666 & ~TRANSMISSION_UMASK_OCTAL)))
         echo "Mask: ${TRANSMISSION_UMASK_OCTAL}"

--- a/transmission/userSetup.sh
+++ b/transmission/userSetup.sh
@@ -42,20 +42,17 @@ if [ -n "$PUID" ] && [ ! "$(id -u root)" -eq "$PUID" ]; then
             ${TRANSMISSION_WATCH_DIR}
 
         echo "Setting permissions for download and incomplete directories"
-        TRANSMISSION_UMASK_OCTAL=$(printf '%03g' $(printf '%o\n' ${TRANSMISSION_UMASK}))
+        TRANSMISSION_UMASK_OCTAL=$(printf '%03g' $(printf '%o\n' $(jq .umask /config/settings.json)))
         DIR_PERMS=$(printf '%o\n' $((0777 & ~TRANSMISSION_UMASK_OCTAL)))
         FILE_PERMS=$(printf '%o\n' $((0666 & ~TRANSMISSION_UMASK_OCTAL)))
         echo "Mask: ${TRANSMISSION_UMASK_OCTAL}"
         echo "Directories: ${DIR_PERMS}"
         echo "Files: ${FILE_PERMS}"
 
-        for THIS_DIR in ${TRANSMISSION_DOWNLOAD_DIR} ${TRANSMISSION_INCOMPLETE_DIR}
-        do
-            find ${THIS_DIR} -type d -print0 | xargs -0 \
-                chmod $(printf '%o\n' $((0777 & ~TRANSMISSION_UMASK_OCTAL)))
-            find ${THIS_DIR} -type f -print0 | xargs -0 \
-                chmod $(printf '%o\n' $((0666 & ~TRANSMISSION_UMASK_OCTAL)))
-        done
+        find "${TRANSMISSION_DOWNLOAD_DIR}" "${TRANSMISSION_INCOMPLETE_DIR}" -type d \
+        -exec chmod $(printf '%o\n' $((0777 & ~TRANSMISSION_UMASK_OCTAL))) {} +
+        find "${TRANSMISSION_DOWNLOAD_DIR}" "${TRANSMISSION_INCOMPLETE_DIR}" -type  f \
+        -exec chmod $(printf '%o\n' $((0666 & ~TRANSMISSION_UMASK_OCTAL))) {} +
 
         echo "Setting permission for watch directory (775) and its files (664)"
         chmod -R o=rX,ug=rwX \

--- a/transmission/userSetup.sh
+++ b/transmission/userSetup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # More/less taken from https://github.com/linuxserver/docker-baseimage-alpine/blob/3eb7146a55b7bff547905e0d3f71a26036448ae6/root/etc/cont-init.d/10-adduser
 
@@ -41,10 +41,21 @@ if [ -n "$PUID" ] && [ ! "$(id -u root)" -eq "$PUID" ]; then
             ${TRANSMISSION_INCOMPLETE_DIR} \
             ${TRANSMISSION_WATCH_DIR}
 
-        echo "Setting permission for files (644) and directories (755)"
-        chmod -R go=rX,u=rwX \
-            ${TRANSMISSION_DOWNLOAD_DIR} \
-            ${TRANSMISSION_INCOMPLETE_DIR} \
+        echo "Setting permissions for download and incomplete directories"
+        TRANSMISSION_UMASK_OCTAL=$(printf '%03g' $(printf '%o\n' ${TRANSMISSION_UMASK}))
+        DIR_PERMS=$(printf '%o\n' $((0777 & ~TRANSMISSION_UMASK_OCTAL)))
+        FILE_PERMS=$(printf '%o\n' $((0666 & ~TRANSMISSION_UMASK_OCTAL)))
+        echo "Mask: ${TRANSMISSION_UMASK_OCTAL}"
+        echo "Directories: ${DIR_PERMS}"
+        echo "Files: ${FILE_PERMS}"
+
+        for THIS_DIR in ${TRANSMISSION_DOWNLOAD_DIR} ${TRANSMISSION_INCOMPLETE_DIR}
+        do
+            find ${THIS_DIR} -type d -print0 | xargs -0 \
+                chmod $(printf '%o\n' $((0777 & ~TRANSMISSION_UMASK_OCTAL)))
+            find ${THIS_DIR} -type f -print0 | xargs -0 \
+                chmod $(printf '%o\n' $((0666 & ~TRANSMISSION_UMASK_OCTAL)))
+        done
 
         echo "Setting permission for watch directory (775) and its files (664)"
         chmod -R o=rX,ug=rwX \


### PR DESCRIPTION
Applies the `TRANSMISSION_UMASK` configuration to the download and incomplete directories. Solves the problem of hardcoded permissions in these directories.

The octal conversion requires changing the `userSetup.sh` script to be interpreted by `bash` instead of `sh`.