### PR TITLE
Ensure transmission shutdown

### DIFF
--- a/transmission/stop.sh
+++ b/transmission/stop.sh
@@ -13,7 +13,7 @@ PID=$(pidof transmission-daemon)
 kill $PID
 # Give transmission-daemon time to shut down
 for i in {1..10}; do
-    ps -p $PID &> /dev/null || break
+    [[ -z "$(pidof transmission-daemon)" ]] && break
     sleep .2
 done
 

--- a/transmission/stop.sh
+++ b/transmission/stop.sh
@@ -21,6 +21,15 @@ do
     [[ $i == 1 ]] && echo "Waiting ${TRANSMISSION_TIMEOUT_SEC}s for transmission-daemon to die"
 done
 
+# Check whether transmission-daemon is still running
+if [[ -z "$(pidof transmission-daemon)" ]]
+then
+    echo "Successfuly closed transmission-daemon"
+else
+    echo "Sending kill signal (SIGKILL) to transmission-daemon"
+    kill -9 $PID
+fi
+
 # If transmission-post-stop.sh exists, run it
 if [[ -x /scripts/transmission-post-stop.sh ]]
 then

--- a/transmission/stop.sh
+++ b/transmission/stop.sh
@@ -11,10 +11,14 @@ fi
 echo "Sending kill signal to transmission-daemon"
 PID=$(pidof transmission-daemon)
 kill $PID
-# Give transmission-daemon time to shut down
-for i in {1..10}; do
+
+# Give transmission-daemon some time to shut down
+TRANSMISSION_TIMEOUT_SEC=${TRANSMISION_TIMEOUT_SEC:-10}
+for i in $(seq $TRANSMISSION_TIMEOUT_SEC)
+do
+    sleep 1
     [[ -z "$(pidof transmission-daemon)" ]] && break
-    sleep .2
+    [[ $i == 1 ]] && echo "Waiting ${TRANSMISSION_TIMEOUT_SEC}s for transmission-daemon to die"
 done
 
 # If transmission-post-stop.sh exists, run it

--- a/transmission/stop.sh
+++ b/transmission/stop.sh
@@ -3,9 +3,9 @@
 # If transmission-pre-stop.sh exists, run it
 if [[ -x /scripts/transmission-pre-stop.sh ]]
 then
-   echo "Executing /scripts/transmission-pre-stop.sh"
-   /scripts/transmission-pre-stop.sh "$@"
-   echo "/scripts/transmission-pre-stop.sh returned $?"
+    echo "Executing /scripts/transmission-pre-stop.sh"
+    /scripts/transmission-pre-stop.sh "$@"
+    echo "/scripts/transmission-pre-stop.sh returned $?"
 fi
 
 echo "Sending kill signal to transmission-daemon"
@@ -33,7 +33,7 @@ fi
 # If transmission-post-stop.sh exists, run it
 if [[ -x /scripts/transmission-post-stop.sh ]]
 then
-   echo "Executing /scripts/transmission-post-stop.sh"
-   /scripts/transmission-post-stop.sh "$@"
-   echo "/scripts/transmission-post-stop.sh returned $?"
+    echo "Executing /scripts/transmission-post-stop.sh"
+    /scripts/transmission-post-stop.sh "$@"
+    echo "/scripts/transmission-post-stop.sh returned $?"
 fi


### PR DESCRIPTION
* Carry and improve #1514 
* Close #1513 

After testing in the container, I found out `ps -p` is not supported in alpine (with `busybox`). So we avoided a regression 😅 

I set the default timeout to 10 seconds, and set the timeout step to 1 second, which both prevent the "Waiting for ..." message if transmission shuts down under 1s, and reduce code verbosity.