### PR TITLE
Remove cause of "yes: Broken pipe" error

### DIFF
--- a/openvpn/pia/update-port.sh
+++ b/openvpn/pia/update-port.sh
@@ -36,8 +36,6 @@ get_auth_token () {
 
 get_auth_token
 
-yes '' | sed 3q
-
 get_sig () {
   pf_getsig=$(curl --insecure --get --silent --show-error \
     --retry $curl_retry --retry-delay $curl_retry_delay --max-time $curl_max_time \


### PR DESCRIPTION
Closes #1532 

I'm pretty sure this line has no purpose (other than printing 3 new lines).