### PR TITLE
Update PIA configure-openvpn.sh with updated URLs

### DIFF
--- a/openvpn/pia/configure-openvpn.sh
+++ b/openvpn/pia/configure-openvpn.sh
@@ -3,14 +3,13 @@
 set -e
 
 # These are the possible bundles from PIA
-# https://www.privateinternetaccess.com/openvpn/openvpn-nextgen.zip
-# https://www.privateinternetaccess.com/openvpn/openvpn-strong-nextgen.zip
-# https://www.privateinternetaccess.com/openvpn/openvpn-ip-nextgen.zip
-# https://www.privateinternetaccess.com/openvpn/openvpn-tcp-nextgen.zip
-# https://www.privateinternetaccess.com/openvpn/openvpn-strong-tcp-nextgen.zip
+# https://www.privateinternetaccess.com/openvpn/openvpn.zip
+# https://www.privateinternetaccess.com/openvpn/openvpn-strong.zip
+# https://www.privateinternetaccess.com/openvpn/openvpn-tcp.zip
+# https://www.privateinternetaccess.com/openvpn/openvpn-strong-tcp.zip
 
 baseURL="https://www.privateinternetaccess.com/openvpn"
-PIA_OPENVPN_CONFIG_BUNDLE=${PIA_OPENVPN_CONFIG_BUNDLE:-"openvpn-nextgen"}
+PIA_OPENVPN_CONFIG_BUNDLE=${PIA_OPENVPN_CONFIG_BUNDLE:-"openvpn"}
 
 if [ -z "$VPN_PROVIDER_HOME" ]; then
     echo "ERROR: Need to have VPN_PROVIDER_HOME set to call this script" && exit 1


### PR DESCRIPTION
It appears that PIA has changed their URLs from "openvpn{-strong/tcp/strong-tcp}-nextgen" to "openvpn{-strong/tcp/strong-tcp}". The old URLs no longer work properly.

See here: https://www.privateinternetaccess.com/helpdesk/kb/articles/where-can-i-find-your-ovpn-files