### PR TITLE
transmission: fix settings ratio limits to float values

### DIFF
--- a/transmission/default-settings.json
+++ b/transmission/default-settings.json
@@ -37,7 +37,7 @@
     "prefetch-enabled": true,
     "queue-stalled-enabled": true,
     "queue-stalled-minutes": 30,
-    "ratio-limit": 2,
+    "ratio-limit": 2.0,
     "ratio-limit-enabled": false,
     "rename-partial-files": true,
     "rpc-authentication-required": false,


### PR DESCRIPTION
Transmission default value for the ratio limit is `2.0`, not `2` (source: https://github.com/transmission/transmission/wiki/Editing-Configuration-Files#scheduling). This slight difference causes the` updateSettings.py` script to treat this setting as `int` instead of `float`. 

Currently, passing float causes the following error:
```
Generating settings.json for Transmission from environment and defaults default-settings.json
Could not coerce TRANSMISSION_RATIO_LIMIT value 4.1 to expected type <class 'int'>
Traceback (most recent call last):
  File "updateSettings.py", line 69, in <module>
    env_value = setting_type(env_value)
ValueError: invalid literal for int() with base 10: '4.1'
```

After applying this patch everything works as expected:
```
Generating settings.json for Transmission from environment and defaults default-settings.json
Overriding ratio-limit because TRANSMISSION_RATIO_LIMIT is set to 4.1
```


In addition to the issue fixed here, there is another issue - any errors inflicted by updateSettings.py should result in a hard fail for the transmission container. Without this user can be unaware of problems. (Potential fix for this is in #1611)