### PR TITLE
transmission: hard fail when settings cannot be converted

### DIFF
--- a/transmission/start.sh
+++ b/transmission/start.sh
@@ -45,7 +45,7 @@ fi
 echo "Updating Transmission settings.json with values from env variables"
 # Ensure TRANSMISSION_HOME is created
 mkdir -p ${TRANSMISSION_HOME}
-python3 /etc/transmission/updateSettings.py /etc/transmission/default-settings.json ${TRANSMISSION_HOME}/settings.json
+python3 /etc/transmission/updateSettings.py /etc/transmission/default-settings.json ${TRANSMISSION_HOME}/settings.json || exit 1
 
 echo "sed'ing True to true"
 sed -i 's/True/true/g' ${TRANSMISSION_HOME}/settings.json


### PR DESCRIPTION
Follow-up to #1610 

Hard fail when `updateSettings.py` fails to set proper configuration. This prevents running transmission with incorrect configuration.