### PR TITLE
Make sure configure-openvpn.sh cannot change the current directory

### DIFF
--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -60,8 +60,12 @@ if [[ -n $OPENVPN_CONFIG_URL ]]; then
   MODIFY_CHOSEN_CONFIG=yeah
 elif [[ -x $VPN_PROVIDER_HOME/configure-openvpn.sh ]]; then
   echo "Provider $OPENVPN_PROVIDER has a custom setup script, executing it"
+  # Preserve $PWD in case it changes when sourcing the script
+  pushd -n "$PWD" > /dev/null
   # shellcheck source=/dev/null
   . "$VPN_PROVIDER_HOME"/configure-openvpn.sh
+  # Restore previous PWD
+  popd > /dev/null
   MODIFY_CHOSEN_CONFIG=yeah
 fi
 


### PR DESCRIPTION
Related to #1615. @clement-z suggested something along these lines.

VYPRVPN sets $PWD to a deleted directory, which causes a cascade of
issues for the rest of `start.sh`.

This saves the current directory before sourcing `configure-openvpn.sh`
scripts, making sure such an issue cannot happen for any VPN.

A proper fix would be to avoid sourcing the script in the first place.

-----

I am unsure if I need to fix that issue at the source: https://github.com/haugene/docker-transmission-openvpn/blob/a4d65774f855a04070766e53346661f48c76fa0e/openvpn/vyprvpn/configure-openvpn.sh#L52

This technically isn't an issue *as long as long the script isn't sourced.* I preferred to solve it once and for all, but once again, changing `$PWD` is just one of many possible side-effect of sourcing that dir.