### PR TITLE
Add DNS resolution checks (fix #1608)

### DIFF
--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -26,6 +26,11 @@ if compgen -e | grep -q "OVERRIDE_DNS"; then
     done
 fi
 
+# Test DNS resolution
+if ! nslookup ${HEALTH_CHECK_HOST:-"google.com"} 1>/dev/null 2>&1; then
+    echo "WARNING: initial DNS resolution test failed"
+fi
+
 # If create_tun_device is set, create /dev/net/tun
 if [[ "${CREATE_TUN_DEVICE,,}" == "true" ]]; then
   echo "Creating TUN device /dev/net/tun"

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -11,6 +11,15 @@ then
     HOST="google.com"
 fi
 
+# Check DNS resolution works
+nslookup $HOST > /dev/null
+STATUS=$?
+if [[ ${STATUS} -ne 0 ]]
+then
+    echo "DNS resolution failed"
+    exit 1
+fi
+
 ping -c 2 -w 5 $HOST # Get at least 2 responses and timeout after 5 seconds
 STATUS=$?
 if [[ ${STATUS} -ne 0 ]]


### PR DESCRIPTION
See #1608 

The main idea is making DNS error clearly identifiable in the logs, and avoid [XY problem](https://xyproblem.info/)-type issues.

The commits add simple `nslookup` calls (using `HEALTH_CHECK_HOST` if set, or defaulting to `google.com`). If the lookup fails, then:

* In `openvpn/start.sh`, only a message is printed, as I guess it is possible to use only IPs for connecting to the VPN, and have DNS resolution set up after openvpn connects;
* In `scripts/healthcheck.sh`, if DNS resolution fails, the container is marked as unhealthy with the message "DNS resolution failed".

It might be worthwhile to also check resolution after connecting to the VPN, especially after #1614 is merged.