### PR TITLE
Fix PIA infinite redirect on config download (see #1619)

### DIFF
--- a/openvpn/pia/configure-openvpn.sh
+++ b/openvpn/pia/configure-openvpn.sh
@@ -21,7 +21,7 @@ find "$VPN_PROVIDER_HOME" -type f ! -name "*.sh" -delete
 # Download and extract wanted bundle into temporary file
 tmp_file=$(mktemp)
 echo "Downloading OpenVPN config bundle $PIA_OPENVPN_CONFIG_BUNDLE into temporary file $tmp_file"
-curl -sSL "${baseURL}/${PIA_OPENVPN_CONFIG_BUNDLE}.zip" -o "$tmp_file"
+curl -sSL --cookie /dev/null "${baseURL}/${PIA_OPENVPN_CONFIG_BUNDLE}.zip" -o "$tmp_file"
 
 echo "Extract OpenVPN config bundle into PIA directory $VPN_PROVIDER_HOME"
 unzip -qjo "$tmp_file" -d "$VPN_PROVIDER_HOME"


### PR DESCRIPTION
Fix #1619 

PIA download link was redirecting and setting a cookie, but those are
disabled by default unless `--cookie` or `--cookie-jar` are given. Since
the cookie was not set, the redirection was attempted again until we
reached the maximum redirection limit.

The `--cookie /dev/null` specifies an empty input cookie, which has the
effect to enable curl's handling of cookies.