### PR TITLE
Fix DNS leak by updating /etc/resolve.conf

### DIFF
--- a/openvpn/tunnelDown.sh
+++ b/openvpn/tunnelDown.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-
 /etc/transmission/stop.sh
+/usr/share/openrc/support/openvpn/down.sh
 [[ ! -f /opt/tinyproxy/stop.sh ]] || /opt/tinyproxy/stop.sh

--- a/openvpn/tunnelUp.sh
+++ b/openvpn/tunnelUp.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+/usr/share/openrc/support/openvpn/up.sh
 /etc/transmission/start.sh "$@"
 [[ ! -f /opt/tinyproxy/start.sh ]] || /opt/tinyproxy/start.sh


### PR DESCRIPTION
Add scripts to OpenVPN startup to update /etc/resolv.conf with VPN providers DNS servers, stopping DNS leakage. 

@clement-z already observed files to complete similar function are available in /etc/openvpn/. Visually they appear near identical (I haven't diff'd them), but both achieve the functionality desired.

This implementation uses:
/usr/share/openrc/support/openvpn/up.sh
/usr/share/openrc/support/openvpn/down.sh

However a valid alternative would be:
/etc/openvpn/up.sh
/etc/openvpn/down.sh

Only other point of note is setting DNS to correct values before transmission starts and after it closes.

Ref Issue #1455 
Prev pull req #1614 (cancelled because I can't manage my branches) (Sorry) 
