### PR TITLE
Increase healthcheck ping timeout

### DIFF
--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -11,7 +11,7 @@ then
     HOST="google.com"
 fi
 
-ping -c 2 -w 5 $HOST # Get at least 2 responses and timeout after 5 seconds
+ping -c 2 -w 10 $HOST # Get at least 2 responses and timeout after 10 seconds
 STATUS=$?
 if [[ ${STATUS} -ne 0 ]]
 then


### PR DESCRIPTION
Fix #1582

For some reason, a 5 seconds timeout on ping specified as `-w 5` is sometimes too short for two pings to go through, most likely because of the delay between pings and...? I don't know, but it nevertheless causes some apparent ping loss, as the last ping is deemed unsuccessful. This in turn marks the container as unhealthy even when it is indeed connected to the VPN and able to reach the internet.

I just increased the timeout to 10 seconds (for 2 pings). This seems awfully long for 2 small pings, but 🤷 