### PR TITLE
Flood UI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,13 @@
+# Build Flood UI seperately to keep image size small
+FROM node:15.5.1-alpine3.10 AS FloodUIBuilder
+WORKDIR /tmp/flood
+
+RUN echo "Build Flood UI" \
+    && apk add --no-cache git \
+    && git clone --depth=1 https://github.com/johman10/flood-for-transmission.git . \
+    && npm install \
+    && npm run build
+
 FROM alpine:3.12
 
 VOLUME /data
@@ -23,6 +33,9 @@ RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /et
     && groupmod -g 1000 users \
     && useradd -u 911 -U -d /config -s /bin/false abc \
     && usermod -G users abc
+
+# Bring over flood UI from previous build stage
+COPY --from=FloodUIBuilder /tmp/flood/public /opt/transmission-ui/flood
 
 # Add configuration and scripts
 ADD openvpn/ /etc/openvpn/

--- a/docs/config-options.md
+++ b/docs/config-options.md
@@ -1,4 +1,5 @@
 ### Required environment options
+
 | Variable           | Function                          | Example                                                                                                 |
 | ------------------ | --------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `OPENVPN_PROVIDER` | Sets the OpenVPN provider to use. | `OPENVPN_PROVIDER=provider`. Supported providers and their config values are listed in the table above. |
@@ -6,6 +7,7 @@
 | `OPENVPN_PASSWORD` | Your OpenVPN password             | `OPENVPN_PASSWORD=asdf`                                                                                 |
 
 ### Network configuration options
+
 | Variable            | Function                                                                                            | Example                                                                                                        |
 | ------------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | `OPENVPN_CONFIG`    | Sets the OpenVPN endpoint to connect to.                                                            | `OPENVPN_CONFIG=UK Southampton`                                                                                |
@@ -17,12 +19,12 @@
 
 Set a custom timezone in tz database format. Look [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for a list of valid timezones. Defaults to UTC.
 
-| Variable                      | Function                                                                                                                    | Example                            |
-| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
-| `TZ`                  | Set Timezone                                                                                                         | `TZ=UTC`                  |
-
+| Variable | Function     | Example  |
+| -------- | ------------ | -------- |
+| `TZ`     | Set Timezone | `TZ=UTC` |
 
 ### Firewall configuration options
+
 When enabled, the firewall blocks everything except traffic to the peer port and traffic to the rpc port from the LOCAL_NETWORK and the internal docker gateway.
 
 If TRANSMISSION_PEER_PORT_RANDOM_ON_START is enabled then it allows traffic to the range of peer ports defined by TRANSMISSION_PEER_PORT_RANDOM_HIGH and TRANSMISSION_PEER_PORT_RANDOM_LOW.
@@ -43,6 +45,7 @@ Because your VPN connection can sometimes fail, Docker will run a health check o
 | `HEALTH_CHECK_HOST` | this host is pinged to check if the network connection still works | `google.com` |
 
 ### Permission configuration options
+
 By default the startup script applies a default set of permissions and ownership on the transmission download, watch and incomplete directories. The GLOBAL_APPLY_PERMISSIONS directive can be used to disable this functionality.
 
 | Variable                   | Function                               | Example                          |
@@ -50,14 +53,15 @@ By default the startup script applies a default set of permissions and ownership
 | `GLOBAL_APPLY_PERMISSIONS` | Disable setting of default permissions | `GLOBAL_APPLY_PERMISSIONS=false` |
 
 ### Alternative web UIs
-You can override the default web UI by setting the ```TRANSMISSION_WEB_HOME``` environment variable. If set, Transmission will look there for the Web Interface files, such as the javascript, html, and graphics files.
 
-[Combustion UI](https://github.com/Secretmapper/combustion), [Kettu](https://github.com/endor/kettu) and [Transmission-Web-Control](https://github.com/ronggang/transmission-web-control/) come bundled with the container. You can enable either of them by setting```TRANSMISSION_WEB_UI=combustion```, ```TRANSMISSION_WEB_UI=kettu``` or ```TRANSMISSION_WEB_UI=transmission-web-control```, respectively. Note that this will override the ```TRANSMISSION_WEB_HOME``` variable if set.
+You can override the default web UI by setting the `TRANSMISSION_WEB_HOME` environment variable. If set, Transmission will look there for the Web Interface files, such as the javascript, html, and graphics files.
 
-| Variable                | Function                         | Example                                                                                                         |
-| ----------------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `TRANSMISSION_WEB_HOME` | Set Transmission web home        | `TRANSMISSION_WEB_HOME=/path/to/web/ui`                                                                         |
-| `TRANSMISSION_WEB_UI`   | Use the specified bundled web UI | `TRANSMISSION_WEB_UI=combustion`, `TRANSMISSION_WEB_UI=kettu` or `TRANSMISSION_WEB_UI=transmission-web-control` |
+[Combustion UI](https://github.com/Secretmapper/combustion), [Kettu](https://github.com/endor/kettu), [Transmission-Web-Control](https://github.com/ronggang/transmission-web-control/), and [Flood](https://github.comjesec/flood) come bundled with the container. You can enable either of them by setting`TRANSMISSION_WEB_UI=combustion`, `TRANSMISSION_WEB_UI=kettu` or `TRANSMISSION_WEB_UI=transmission-web-control`, respectively. Note that this will override the `TRANSMISSION_WEB_HOME` variable if set.
+
+| Variable                | Function                         | Example                                                                                                                                       |
+| ----------------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TRANSMISSION_WEB_HOME` | Set Transmission web home        | `TRANSMISSION_WEB_HOME=/path/to/web/ui`                                                                                                       |
+| `TRANSMISSION_WEB_UI`   | Use the specified bundled web UI | `TRANSMISSION_WEB_UI=combustion`, `TRANSMISSION_WEB_UI=kettu`, `TRANSMISSION_WEB_UI=transmission-web-control`, or `TRANSMISSION_WEB_UI=flood` |
 
 ### Transmission configuration options
 
@@ -97,15 +101,15 @@ This might lead to the default route (your untunneled connection) to be used.
 
 To drop the default route set the environment variable `DROP_DEFAULT_ROUTE` to `true`.
 
-*Note*: This is not compatible with all VPNs. You can check your iptables routing with the `ip r` command in a running container.
+_Note_: This is not compatible with all VPNs. You can check your iptables routing with the `ip r` command in a running container.
 
 ### Changing logging locations
 
-By default Transmission will log to a file in `TRANSMISSION_HOME/transmission.log`. 
+By default Transmission will log to a file in `TRANSMISSION_HOME/transmission.log`.
 
 To log to stdout instead set the environment variable `LOG_TO_STDOUT` to `true`.
 
-*Note*: By default stdout is what container engines read logs from. Set this to true to have Tranmission logs in commands like `docker logs` and `kubectl logs`. OpenVPN currently only logs to stdout.
+_Note_: By default stdout is what container engines read logs from. Set this to true to have Tranmission logs in commands like `docker logs` and `kubectl logs`. OpenVPN currently only logs to stdout.
 
 ### Custom scripts
 


### PR DESCRIPTION
## Bundle the [Flood](https://github.com/jesec/flood) web interface with the default image. 

In order to reduce the output size of the final image, multi-stage builds are utilized. First, in a temporary build container, (since there is no compiled tarball available) the Flood source code is cloned and compiled. Then, the resulting build artifacts are copied to the final image. 

Overall the image only grows but ~1MB in size, but takes slightly longer to build due to the added complexity. 

Docs are updated, and there are also some small formatting changes in this PR. 

Resolves #1661.