### PR TITLE
add ghcr publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,9 @@ jobs:
       - run:
           name: Login to Docker Hub
           command: echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
+      - run:
+          name: Login to GitHub Container Registry
+          command: echo $GITHUB_PASS | docker login ghcr.io -u $DOCKER_USER --password-stdin
       - calculate-tag-name
       - run:
           name: Set up buildx and build/push images
@@ -47,7 +50,10 @@ jobs:
             docker buildx use mybuilder
             docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
             docker buildx ls
-            docker buildx build -t haugene/transmission-openvpn:$IMAGE_TAG --progress plain \
+            docker buildx build \
+              -t haugene/transmission-openvpn:$IMAGE_TAG \
+              -t ghcr.io/haugene/transmission-openvpn:$IMAGE_TAG \
+              --progress plain \
               --platform linux/arm,linux/arm64,linux/amd64 \
               --build-arg REVISION=$CIRCLE_SHA1 \
               --push .


### PR DESCRIPTION
PR for https://github.com/haugene/docker-transmission-openvpn/issues/1633

# PREREQUISITES  
* create github personal access token with permissions for read/write packages as seen [here](https://docs.github.com/en/packages/guides/migrating-to-github-container-registry-for-docker-images)
* add the token as a Circle CI variable named GITHUB_PASS

# POST MERGE  
* after first build has been published, package needs to be made public (defaults to private)