### PR TITLE
Revert "Fix DNS leak by updating /etc/resolve.conf"

### DIFF
--- a/openvpn/tunnelDown.sh
+++ b/openvpn/tunnelDown.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
+
 /etc/transmission/stop.sh
-/usr/share/openrc/support/openvpn/down.sh
 [[ ! -f /opt/tinyproxy/stop.sh ]] || /opt/tinyproxy/stop.sh

--- a/openvpn/tunnelUp.sh
+++ b/openvpn/tunnelUp.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-/usr/share/openrc/support/openvpn/up.sh
 /etc/transmission/start.sh "$@"
 [[ ! -f /opt/tinyproxy/start.sh ]] || /opt/tinyproxy/start.sh


### PR DESCRIPTION
Reverts haugene/docker-transmission-openvpn#1621
this needs to be reworked as it will cause problems with no dns resolution before the tunnel is setup (cannot resolve vpn hostname )