### PR TITLE
Update faq.md to explain RTNETLINK error from invalid subnet mask/route

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -31,6 +31,27 @@ Or you could use a test torrent service to download a torrent file and then you 
 
 [TODO](https://github.com/haugene/docker-transmission-openvpn/issues/1558): Conflicting LOCAL_NETWORK values. Short explanation and link to [networking](vpn-networking.md)
 
+## RTNETLINK answers: Invalid argument
+
+This can occur because you have specified an invalid **subnet** or possibly specified an IP Address in CIDR format instead of a subnet. Your LOCAL_NETWORK property must be aimed at a **subnet** and not at an IP Address. 
+
+A valid example would be
+
+     ```
+     LOCAL_NETWORK=10.80.0.0/24
+     ```
+
+but an invalid target route that would cause this error might be 
+
+     ```
+     #Invalid because the subnet for this range would be 10.20.30.0/24
+     LOCAL_NETWORK=10.20.30.45/24
+     ```
+
+To check your value, you can use a [subnet calculator](https://www.calculator.net/ip-subnet-calculator.html). 
+* Enter your IP Address - the portion before the mask, `10.20.30.45` here
+* select the subnet that matches - the `/24` portion here
+* Take the Network Address that is returned - `10.20.30.0` in this case 
 
 ## TUNSETIFF tun: Operation not permitted
 


### PR DESCRIPTION
Was running into me being dumb and not entering an actual subnet ID, wrote a quick FAQ entry and directions to get Network ID instead of the IP address of the gateway
toward #1558 