### PR TITLE
Update static copy of Table of Contents on faq.md

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,10 +2,13 @@
 * [The container runs, but I can't access the web ui](#the_container_runs_but_i_cant_access_the_web_ui)
 * [How do I verify that my traffic is using VPN](#how_do_i_verify_that_my_traffic_is_using_vpn)
 * [RTNETLINK answers: File exists](#rtnetlink_answers_file_exists)
+* [RTNETLINK answers: Invalid argument](#rtnetlink_answers_invalid_argument)
 * [TUNSETIFF tun: Operation not permitted](#tunsetiff_tun_operation_not_permitted)
 * [Error resolving host address](#error_resolving_host_address)
-* [AUTH: Received control message: AUTH_FAILED](#auth_received_control_message_auth_failed)
 * [Container loses connection after some time](#container_loses_connection_after_some_time)
+  * [Set the ping-exit option for OpenVPN and restart-flag in Docker](#set_the_ping-exit_option_for_openvpn_and_restart-flag_in_docker)
+  * [Use a third party tool to monitor and restart the container](#use_a_third_party_tool_to_monitor_and_restart_the_container)
+* [AUTH: Received control message: AUTH_FAILED](#auth_received_control_message_auth_failed)
 
 ## The container runs, but I can't access the web ui
 


### PR DESCRIPTION
faq.md currently has both a static Table of Contents and a generated one on the right. This PR updates the static copy to include all the headers on the page currently, mirroring the dynamic one on the right (screenshot from before PR below)
https://i.imgur.com/mfmUbwu.png
![image](https://user-images.githubusercontent.com/3719116/106015193-3a9d3000-608c-11eb-93a8-29f84795c473.png)
