### PR TITLE
Moving configs to separate repo

### DIFF
--- a/openvpn/fetch-external-configs.sh
+++ b/openvpn/fetch-external-configs.sh
@@ -1,0 +1,42 @@
+#! /bin/bash
+
+VPN_CONFIG_SOURCE_TYPE="${VPN_CONFIG_SOURCE_TYPE:-github_zip}"
+
+# Set default GitHub config repo
+GITHUB_CONFIG_SOURCE_REPO="${GITHUB_CONFIG_SOURCE_REPO:-haugene/vpn-configs-contrib}"
+GITHUB_CONFIG_SOURCE_REVISION="${GITHUB_CONFIG_SOURCE_REVISION:-main}"
+
+if [[ "${VPN_CONFIG_SOURCE_TYPE}" == "github_zip" ]]; then
+
+  # Concatenate URL for config bundle from the given GitHub repo
+  GITHUB_CONFIG_BUNDLE_URL="https://github.com/${GITHUB_CONFIG_SOURCE_REPO}/archive/${GITHUB_CONFIG_SOURCE_REVISION}.zip"
+  
+  # Create a temporary file and download bundle to it
+  config_repo_temp_zip_file=$(mktemp)
+  echo "Downloading configs from ${GITHUB_CONFIG_BUNDLE_URL} into ${config_repo_temp_zip_file}"
+  curl -sSL -o "${config_repo_temp_zip_file}" "${GITHUB_CONFIG_BUNDLE_URL}"
+
+  # Create a temporary folder and extract configs there
+  config_repo_temp_dir=$(mktemp -d)
+  echo "Extracting configs to ${config_repo_temp_dir}"
+  unzip -q "${config_repo_temp_zip_file}" -d "${config_repo_temp_dir}"
+
+  # Find the specified provider folder. Should be under <tmpDir>/<some-root-folder>/openvpn/<provider>
+  provider_configs=$(find "${config_repo_temp_dir}"/*/openvpn -type d -name "${VPN_PROVIDER}")
+  if [[ -z "${provider_configs}" ]]; then
+    echo "ERROR: Could not find any configs for provider ${VPN_PROVIDER^^} in downloaded configs"
+    exit 1
+  fi
+
+  # Replace current provider home folder with the downloaded directory
+  echo "Found configs for ${VPN_PROVIDER^^} in ${provider_configs}, will replace current content in ${VPN_PROVIDER_HOME}"
+  rm -r "${VPN_PROVIDER_HOME}"
+  mv "${provider_configs}" "${VPN_PROVIDER_HOME}"
+
+  # Clean up temporary files
+  rm -rf "${config_repo_temp_zip_file}" "${config_repo_temp_dir}"
+
+else
+    "ERROR: VPN config source type ${VPN_CONFIG_SOURCE_TYPE} does not exist..."
+    exit 1
+fi

--- a/openvpn/fetch-external-configs.sh
+++ b/openvpn/fetch-external-configs.sh
@@ -24,7 +24,7 @@ if [[ "${VPN_CONFIG_SOURCE_TYPE}" == "github_zip" ]]; then
   # Create a temporary file and download bundle to it
   config_repo_temp_zip_file=$(mktemp)
   echo "Downloading configs from ${GITHUB_CONFIG_BUNDLE_URL} into ${config_repo_temp_zip_file}"
-  curl -sSL -o "${config_repo_temp_zip_file}" "${GITHUB_CONFIG_BUNDLE_URL}"
+  curl -sSL --fail -o "${config_repo_temp_zip_file}" "${GITHUB_CONFIG_BUNDLE_URL}"
 
   # Create a temporary folder and extract configs there
   config_repo_temp_dir=$(mktemp -d)

--- a/openvpn/fetch-external-configs.sh
+++ b/openvpn/fetch-external-configs.sh
@@ -1,5 +1,9 @@
 #! /bin/bash
 
+set -o nounset
+set -o errexit
+set -o pipefail
+
 VPN_CONFIG_SOURCE_TYPE="${VPN_CONFIG_SOURCE_TYPE:-github_zip}"
 
 # Set default GitHub config repo
@@ -7,6 +11,12 @@ GITHUB_CONFIG_SOURCE_REPO="${GITHUB_CONFIG_SOURCE_REPO:-haugene/vpn-configs-cont
 GITHUB_CONFIG_SOURCE_REVISION="${GITHUB_CONFIG_SOURCE_REVISION:-main}"
 
 if [[ "${VPN_CONFIG_SOURCE_TYPE}" == "github_zip" ]]; then
+
+  function cleanup {
+    echo "Cleanup: deleting ${config_repo_temp_zip_file} and ${config_repo_temp_dir}"
+    rm -rf "${config_repo_temp_zip_file}" "${config_repo_temp_dir}"
+  }
+  trap cleanup EXIT
 
   # Concatenate URL for config bundle from the given GitHub repo
   GITHUB_CONFIG_BUNDLE_URL="https://github.com/${GITHUB_CONFIG_SOURCE_REPO}/archive/${GITHUB_CONFIG_SOURCE_REVISION}.zip"
@@ -33,8 +43,7 @@ if [[ "${VPN_CONFIG_SOURCE_TYPE}" == "github_zip" ]]; then
   rm -r "${VPN_PROVIDER_HOME}"
   mv "${provider_configs}" "${VPN_PROVIDER_HOME}"
 
-  # Clean up temporary files
-  rm -rf "${config_repo_temp_zip_file}" "${config_repo_temp_dir}"
+  exit 0
 
 else
     "ERROR: VPN config source type ${VPN_CONFIG_SOURCE_TYPE} does not exist..."

--- a/openvpn/modify-openvpn-config.sh
+++ b/openvpn/modify-openvpn-config.sh
@@ -19,19 +19,20 @@ CONFIG_MOD_PING=${CONFIG_MOD_PING:-"1"}
 
 ## Option 1 - Change the auth-user-pass line to point to credentials file
 if [[ $CONFIG_MOD_USERPASS == "1" ]]; then
-    [[ "${DEBUG}" == "true" ]] && echo "Point auth-user-pass option to the username/password file"
+    echo "Modification: Point auth-user-pass option to the username/password file"
     sed -i "s#auth-user-pass.*#auth-user-pass /config/openvpn-credentials.txt#g" "$CONFIG"
 fi
 
 ## Option 2 - Change the ca certificate path to point relative to the provider home
 if [[ $CONFIG_MOD_CA_CERTS == "1" ]]; then
-    [[ "${DEBUG}" == "true" ]] && echo "Change ca certificate path"
+    echo "Modification: Change ca certificate path"
     config_directory=$(dirname "$CONFIG")
     sed -i "s#^ca #ca $config_directory/#g" "$CONFIG"
 fi
 
 ## Option 3 - Update ping options to exit the container, so Docker will restart it
 if [[ $CONFIG_MOD_PING == "1" ]]; then
+    echo "Modification: Change ping options"
     # Remove any old options
     sed -i "s/^ping.*//g" "$CONFIG"
 

--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -46,8 +46,8 @@ fi
 
 # If no OPENVPN_PROVIDER is given, we default to "custom" provider.
 VPN_PROVIDER="${OPENVPN_PROVIDER:-custom}"
-VPN_PROVIDER="${VPN_PROVIDER,,}" # to lowercase
-VPN_PROVIDER_HOME="/etc/openvpn/${VPN_PROVIDER}"
+export VPN_PROVIDER="${VPN_PROVIDER,,}" # to lowercase
+export VPN_PROVIDER_HOME="/etc/openvpn/${VPN_PROVIDER}"
 mkdir -p "$VPN_PROVIDER_HOME"
 
 # Make sure that we have enough information to start OpenVPN

--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -o errexit
+set -o pipefail
+
 ##
 # Get some initial setup out of the way.
 ##


### PR DESCRIPTION
As discussed in #1489 and that we have been planning for a while. We should move all the .ovpn config files to a separate repo to make a clearer distinction between config and code. That would reduce the amount of PRs and issues posted here and we could set up a codeowner-structure or otherwise engage more of the community to maintain configs.

Separating the configs like this also enables people to fork, edit and test new configs without getting their PRs merged. While many of our contributors are familiar with git, this would allow any user to fork the config repo and copy-paste a config from his/her provider and be up and running.

The PR is not done. But it might not be far from it. I'm wondering what you think about naming of the variables and what we'll call these "modes" of operation. I'm not sure that we'll forever say that scripts live here, configs live there, so there should be some flexibility. For now this will default to "business as usual" and you have to say "static" config to make it download it. So it's opt-in.

As a final solution I'm up for suggestions, but I'm thinking that the default mode should be "auto" where we check if there are config scripts in the container for the given provider. If so we assume that they should be used to fetch/configure the provider. If we can't find them then we download the zip and look there. And then we fail if we can't find it.

If someone wanted to run their own scripts, they could then say "static" and point to their own repo and their scripts would be run instead. Calling it "static" is therefore a bit misleading for that scenario.

Anyways. I must be off for tonight! To be continued...