### PR TITLE
WIP: More correct start and stop scripts for Transmission

### DIFF
--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -137,7 +137,7 @@ echo "${TRANSMISSION_RPC_PASSWORD}" >> /config/transmission-credentials.txt
 # Persist transmission settings for use by transmission-daemon
 python3 /etc/openvpn/persistEnvironment.py /etc/transmission/environment-variables.sh
 
-TRANSMISSION_CONTROL_OPTS="--script-security 2 --up-delay --up /etc/openvpn/tunnelUp.sh --down /etc/openvpn/tunnelDown.sh"
+TRANSMISSION_CONTROL_OPTS="--script-security 2 --up-delay --up /etc/openvpn/tunnelUp.sh --route-pre-down /etc/openvpn/tunnelDown.sh"
 
 ## If we use UFW or the LOCAL_NETWORK we need to grab network config info
 if [[ "${ENABLE_UFW,,}" == "true" ]] || [[ -n "${LOCAL_NETWORK-}" ]]; then


### PR DESCRIPTION
As discussed in #1362 the route-up and route-pre-down options might be a better fit to start and stop Transmission with.
Some additional changes needs to be added to get the route-up script to work, but route-pre-down seems straight forward.

With this done. Will that automatically bring back support for the providers that run some `up /etc/openvpn/update-resolv-conf` action that has until now broken our start/stop mechanism? :thinking: 