### PR TITLE
Don't fail `rm` if VPN_PROVIDER_HOME doesn't exist.

### DIFF
--- a/openvpn/fetch-external-configs.sh
+++ b/openvpn/fetch-external-configs.sh
@@ -40,7 +40,7 @@ if [[ "${VPN_CONFIG_SOURCE_TYPE}" == "github_zip" ]]; then
 
   # Replace current provider home folder with the downloaded directory
   echo "Found configs for ${VPN_PROVIDER^^} in ${provider_configs}, will replace current content in ${VPN_PROVIDER_HOME}"
-  rm -r "${VPN_PROVIDER_HOME}"
+  rm -rf "${VPN_PROVIDER_HOME}"
   mv "${provider_configs}" "${VPN_PROVIDER_HOME}"
 
   exit 0


### PR DESCRIPTION
There are only very few providers's directories in https://github.com/haugene/docker-transmission-openvpn/tree/dev/openvpn and VPN_PROVIDER_HOME might very likely be missing for many providers without bundled setup scripts.