### PR TITLE
CONFIG_MOD_PING breaks config files

### DIFF
--- a/openvpn/modify-openvpn-config.sh
+++ b/openvpn/modify-openvpn-config.sh
@@ -34,9 +34,11 @@ fi
 if [[ $CONFIG_MOD_PING == "1" ]]; then
     echo "Modification: Change ping options"
     # Remove any old options
-    sed -i "s/^ping.*//g" "$CONFIG"
+    sed -i "/^inactive.*$/d" "$CONFIG"
+    sed -i "/^ping.*$/d" "$CONFIG"
 
     # Add new ones
+    sed -i "\$q" "$CONFIG" # Ensure config ends with a line feed
     echo "inactive 3600" >> "$CONFIG"
     echo "ping 10" >> "$CONFIG"
     echo "ping-exit 60" >> "$CONFIG"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  Also, please create PRs to DEV branch, !!NOT!! MASTER branch. 
  If necessary, when we review or such, 
  make a comment if you feel this needs to go to master directly, 
  otherwise we will merge to master when necesssary.
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Leave this section emtpy if this PR is NOT a breaking change.
-->
```txt
None
```


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
```txt
When "CONFIG_MOD_PING = 1" it can result in non-functional config files.
Especially when used in conjunction with "VPN_CONFIG_SOURCE = internal".
Namely because it doesn't ensure new options are being appended on a new line.
Also updated the remove code to ensure clean-up of "inactive" and avoid leaving lots of unnecessary empty lines.
```


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

<!--
- This PR fixes or closes issue: ```fixes #```
- This PR is related to issue: ```relates to #```
- Link to documentation updated (if done separately): ```https://...```
-->
- None

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:

<!--
- [ ] Documentation added/updated
-->
- None

<!-- Please check *Preview* before submitting -->
