### PR TITLE
Reflected watch directory support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY --from=TransmissionUIs /opt/transmission-ui /opt/transmission-ui
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     dumb-init openvpn transmission-daemon transmission-cli privoxy \
-    tzdata dnsutils iputils-ping ufw openssh-client git jq curl wget unrar unzip bc \
+    tzdata dnsutils iputils-ping ufw openssh-client git jq curl wget unrar unzip bc inotify-tools coreutils \
     && ln -s /usr/share/transmission/web/style /opt/transmission-ui/transmission-web-control \
     && ln -s /usr/share/transmission/web/images /opt/transmission-ui/transmission-web-control \
     && ln -s /usr/share/transmission/web/javascript /opt/transmission-ui/transmission-web-control \

--- a/docs/config-options.md
+++ b/docs/config-options.md
@@ -54,6 +54,15 @@ By default the startup script applies a default set of permissions and ownership
 | -------------------------- | -------------------------------------- | -------------------------------- |
 | `GLOBAL_APPLY_PERMISSIONS` | Disable setting of default permissions | `GLOBAL_APPLY_PERMISSIONS=false` |
 
+### Reflected watch directory
+
+Similar to Transmission's watch feature, this sets a watch directory for automatically adding torrents, but sets their download location relative to `TRANSMISSION_DOWNLOAD_DIR` to the same subdirectory position as the torrent file.  For example, a torrent added to a REFLECTED_WATCH_DIR set to /data/reflected_watch/ISOs would download to /data/completed/ISOs.
+
+
+| Variable             | Function                               | Example                                      |
+| ---------------------| -------------------------------------- | -------------------------------------------- |
+| `REFLECTED_WATCH_DIR`| Sets directory to reflectively watch   | `REFLECTED_WATCH_DIR=/data/reflected_watch`  |
+
 ### Alternative Web UIs
 
 This container comes bundled with some alternative Web UIs:

--- a/openvpn/persistEnvironment.py
+++ b/openvpn/persistEnvironment.py
@@ -21,7 +21,8 @@ wanted_variables = {
     'GLOBAL_APPLY_PERMISSIONS',
     'LOG_TO_STDOUT',
     'DISABLE_PORT_UPDATER',
-    'TZ'
+    'TZ',
+    'REFLECTED_WATCH_DIR'
 }
 
 variables_to_persist = {}

--- a/scripts/reflected-watch.sh
+++ b/scripts/reflected-watch.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+inotifywait -q -r -m $1 --format %w%f -e create |
+while read file; do
+  if echo "$file" | grep -iq "\.torrent" ; then
+    canonfile=$(readlink -f "$file")
+    relpath=$(realpath --relative-to="$REFLECTED_WATCH_DIR" "$canonfile")
+    dir=$(dirname "$relpath")
+
+    if echo `basename "$file"` | grep -iq "^\._"; then
+      echo
+    else
+      counter=0
+      while : ; do
+        if [ "$counter" -gt "10" ]; then break; fi
+        sleep 0.5s
+        a=`stat -c%s "$canonfile"`
+        if [ "$?" -ne "0" ]; then break; fi
+        echo "$canonfile" stat: "$a"
+        if [ "$a" -ne "0" ]; then break; fi
+        counter=`expr "$counter" + 1`
+      done
+      while : ; do
+        a=`stat -c%s "$canonfile"`
+        if [ "$?" -ne "0" ]; then break; fi
+        sleep 5s
+        if [ "$a" -eq `stat -c%s "$canonfile"` ]; then break; fi
+      done
+      a=`stat -c%s "$canonfile"`
+      if [ "$?" -eq "0" ]; then
+        transmission-remote -a "$canonfile" -w "$TRANSMISSION_DOWNLOAD_DIR/$dir";
+              # workaround for --trash-torrent not working
+        [ "$TRANSMISSION_TRASH_ORIGINAL_TORRENT_FILES" = "true" ] && rm -f "$canonfile"
+      fi
+    fi
+  fi
+done

--- a/transmission/start.sh
+++ b/transmission/start.sh
@@ -89,6 +89,11 @@ if [[ -x /etc/openvpn/${OPENVPN_PROVIDER,,}/update-port.sh && -z $DISABLE_PORT_U
   exec /etc/openvpn/${OPENVPN_PROVIDER,,}/update-port.sh &
 fi
 
+if [[ ! -z "$REFLECTED_WATCH_DIR" ]]; then
+  echo "Reflectively watching"
+  exec /etc/scripts/reflected-watch.sh "$REFLECTED_WATCH_DIR" &
+fi
+
 # If transmission-post-start.sh exists, run it
 if [[ -x /scripts/transmission-post-start.sh ]]; then
   echo "Executing /scripts/transmission-post-start.sh"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  Also, please create PRs to DEV branch, !!NOT!! MASTER branch. 
  If necessary, when we review or such, 
  make a comment if you feel this needs to go to master directly, 
  otherwise we will merge to master when necesssary.
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Leave this section emtpy if this PR is NOT a breaking change.
-->
```txt
```


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is an opinionated take on multiple watch directory support.  This PR adds a script based on inotify that recursively watches a directory, specified by a new environment variable `REFLECTED_WATCH_DIR`, for newly created .torrent files.  It adds them to Transmission and sets their download location to the same subdirectory, but relative to `TRANSMISSION_DOWNLOAD_DIR`.  Better explained with an example:

* REFLECTED_WATCH_DIR is `/data/refl_watch`:
* User adds Ubuntu-iso.torrent to `/data/refl_watch/ISOs/`
* Transmission will download the files to `/data/completed/ISOs/`

It basically works the same way Transmission's current watch functionality does, but it "reflects" the download location based on where you dropped the .torrent file.  

I realized after the fact this could all really be done in a `transmission-post-start.sh` script, but if the functionality is useful enough, it would be great to add it to the image.

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to a this container)
- [ ] Breaking change (fix/feature causing existing functionality to break)


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Based on a script found here: https://forum.transmissionbt.com/viewtopic.php?t=15705

* Adds dependencies of `inotify-tools` and `coreutils` (for `realpath` with --relative-to support)
* The size checking code is kinda ugly.  The better alternative would be to monitor for `close_write` events, but I could not get those to fire in the container when adding a torrent file.  Maybe I am missing something.


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated

<!-- Please check *Preview* before submitting -->
