### PR TITLE
Fix IP leak for first few seconds after tunnel up

### DIFF
--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -175,7 +175,7 @@ echo "${TRANSMISSION_RPC_PASSWORD}" >> /config/transmission-credentials.txt
 # Persist transmission settings for use by transmission-daemon
 python3 /etc/openvpn/persistEnvironment.py /etc/transmission/environment-variables.sh
 
-TRANSMISSION_CONTROL_OPTS="--script-security 2 --up-delay --up /etc/openvpn/tunnelUp.sh --route-pre-down /etc/openvpn/tunnelDown.sh"
+TRANSMISSION_CONTROL_OPTS="--script-security 2 --route-up /etc/openvpn/tunnelUp.sh --route-pre-down /etc/openvpn/tunnelDown.sh"
 
 ## If we use UFW or the LOCAL_NETWORK we need to grab network config info
 if [[ "${ENABLE_UFW,,}" == "true" ]] || [[ -n "${LOCAL_NETWORK-}" ]]; then


### PR DESCRIPTION
<!--
  Please, vpn provider updates should ONLY be done at the new repo:
  https://github.com/haugene/vpn-configs-contrib
  No updates and such will be accepted here
-->
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  Also, please create PRs to DEV branch, !!NOT!! MASTER branch. 
  If necessary, when we review or such, 
  make a comment if you feel this needs to go to master directly, 
  otherwise we will merge to master when necesssary.
-->
<!--## Breaking change-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Leave this section emtpy if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
For the first few seconds after transmission and tinyproxy start, their traffic is not routed through the VPN. This is because we are calling openvpn with the option `--up /etc/openvpn/tunnelUp.sh`, and the `--up` script runs before ip routes are added. In other words, the VPN will be connected, but traffic will be routed outside of the VPN interface because openvpn has not changed the routing tables with the `ip route` command. In my testing, this seems to not cause an IP leak for transmission, because transmission takes a few seconds to load (however, depending on your setup, it could be a problem). I did find that tinyproxy can leak a few requests though, because tinyproxy starts up faster.

To fix this leak, I changed `--up` to `--route-up`, which runs after openvpn has modified the routing table. Here are the relevant docs from the [openvpn reference manual](https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/):
> --up _cmd_
    Run command _cmd_ after successful TUN/TAP device open (pre --user UID change). _cmd_ consists of a path to script (or executable program), optionally followed by arguments. The path and arguments may be single- or double-quoted and/or escaped using a backslash, and should be separated by one or more spaces. **The up command is useful for specifying route commands** which route IP traffic destined for private subnets which exist at the other end of the VPN connection into the tunnel...

> --route-up _cmd_
    Run command _cmd_ **after routes are added**, subject to --route-delay. _cmd_ consists of a path to script (or executable program), optionally followed by arguments. The path and arguments may be single- or double-quoted and/or escaped using a backslash, and should be separated by one or more spaces...

(emphasis mine)



## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to a this container)
- [ ] Breaking change (fix/feature causing existing functionality to break)


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
<!--
- This PR fixes or closes issue: ```fixes #```
- This PR is related to issue: ```relates to #```
- Link to documentation updated (if done separately): ```https://...```
-->
To test the IP leak on your own, create a script `print-ip.sh`:
```bash
#!/bin/bash

echo "start $0, RUNNING_IN_BACKGROUND=${RUNNING_IN_BACKGROUND:-false}"

if [ -z "$RUNNING_IN_BACKGROUND" ]; then
  # emulate launching program in background (like transmission or tinyproxy)
  RUNNING_IN_BACKGROUND=true "$0" &
else
  # running in background now
  curl -s https://icanhazip.com/
fi
```

Now, run the docker container with a volume that mounts `print.sh` on `/etc/openvpn/tunnelUp.sh` (for example `-v /tmp/print-ip.sh:/etc/openvpn/tunnelUp.sh:ro`. When you run the container, it will print out your non-VPN IP address:
 ```
Fri Jun 10 01:23:00 2022 TUN/TAP device tun0 opened
Fri Jun 10 01:23:00 2022 TUN/TAP TX queue length set to 100
Fri Jun 10 01:23:00 2022 /sbin/ip link set dev tun0 up mtu 1500
Fri Jun 10 01:23:00 2022 /sbin/ip addr add dev tun0 local 10.12.0.98 peer 10.12.0.97
Fri Jun 10 01:23:00 2022 /etc/openvpn/tunnelUp.sh tun0 1500 1556 10.12.0.98 10.12.0.97 init
start /etc/openvpn/tunnelUp.sh, RUNNING_IN_BACKGROUND=false
start /etc/openvpn/tunnelUp.sh, RUNNING_IN_BACKGROUND=true
1.2.3.4  <-- non-VPN IP address
Fri Jun 10 01:23:02 2022 /sbin/ip route add 44.55.66.77/32 via 192.168.100.1
Fri Jun 10 01:23:02 2022 /sbin/ip route add 0.0.0.0/1 via 10.12.0.97
Fri Jun 10 01:23:02 2022 /sbin/ip route add 128.0.0.0/1 via 10.12.0.97
Fri Jun 10 01:23:02 2022 /sbin/ip route add 10.12.0.1/32 via 10.12.0.97
Fri Jun 10 01:23:02 2022 Initialization Sequence Completed
```

With the patch:
```
Fri Jun 10 01:24:00 2022 TUN/TAP device tun0 opened
Fri Jun 10 01:24:00 2022 TUN/TAP TX queue length set to 100
Fri Jun 10 01:24:00 2022 /sbin/ip link set dev tun0 up mtu 1500
Fri Jun 10 01:24:00 2022 /sbin/ip addr add dev tun0 local 10.12.0.98 peer 10.12.0.97
Fri Jun 10 01:24:02 2022 /sbin/ip route add 44.55.66.77/32 via 192.168.100.1
Fri Jun 10 01:24:03 2022 /sbin/ip route add 0.0.0.0/1 via 10.12.0.97
Fri Jun 10 01:24:03 2022 /sbin/ip route add 128.0.0.0/1 via 10.12.0.97
Fri Jun 10 01:24:03 2022 /sbin/ip route add 10.12.0.1/32 via 10.12.0.97
start /etc/openvpn/tunnelUp.sh, RUNNING_IN_BACKGROUND=false
Fri Jun 10 01:24:03 2022 Initialization Sequence Completed
start /etc/openvpn/tunnelUp.sh, RUNNING_IN_BACKGROUND=true
44.55.66.77  <-- VPN IP address
```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
<!--
If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated
-->
<!-- Please check *Preview* before submitting -->
