### PR TITLE
 Fix scripts to work with --route-up, and update settings.json in transmission-home folder 

### DIFF
--- a/openvpn/tunnelUp.sh
+++ b/openvpn/tunnelUp.sh
@@ -51,7 +51,7 @@ if [[ "${PEER_DNS,,}" == "true" ]]; then
         fi
 fi
 
-/etc/transmission/start.sh "$@"
+/etc/transmission/start.sh
 [[ -f /opt/privoxy/start.sh && -x /opt/privoxy/start.sh ]] && /opt/privoxy/start.sh
 
 exit 0

--- a/transmission/start.sh
+++ b/transmission/start.sh
@@ -54,6 +54,8 @@ if [[ "shift" = "$TRANSMISSION_WEB_UI" ]]; then
   export TRANSMISSION_WEB_HOME=/opt/transmission-ui/shift
 fi
 
+. /etc/transmission/userSetup.sh
+
 echo "Updating Transmission settings.json with values from env variables"
 # Ensure TRANSMISSION_HOME is created
 mkdir -p ${TRANSMISSION_HOME}
@@ -67,8 +69,6 @@ if [[ ! -e "/dev/random" ]]; then
   echo "INFO: /dev/random not found - symlink to /dev/urandom"
   ln -s /dev/urandom /dev/random
 fi
-
-. /etc/transmission/userSetup.sh
 
 if [[ "true" = "$DROP_DEFAULT_ROUTE" ]]; then
     echo "DROPPING DEFAULT ROUTE"


### PR DESCRIPTION
<!--
  Please, vpn provider updates should ONLY be done at the new repo:
  https://github.com/haugene/vpn-configs-contrib
  No updates and such will be accepted here
-->
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  Also, please create PRs to DEV branch, !!NOT!! MASTER branch. 
  If necessary, when we review or such, 
  make a comment if you feel this needs to go to master directly, 
  otherwise we will merge to master when necesssary.
-->
<!--## Breaking change-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Leave this section emtpy if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
OpenVPN calls the `--up` script with arguments and environment variables, but it calls `--route-up` only with environment variables. Here, I switched the scripts to use the corresponding environment variables instead of arguments.

While I was testing this patch, I noticed another bug, related to #2020. The `updateSettings.py` script does not work for the legacy config location (`/data/transmission-home`), because we check for the legacy config folder and update `TRANSMISSION_HOME` after the python script has already run. I moved the `userSetup.sh` script before `updateSettings.py` to fix this.


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to a this container)
- [ ] Breaking change (fix/feature causing existing functionality to break)


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes: #2081

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.

<!--If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated-->

<!-- Please check *Preview* before submitting -->
