### PR TITLE
removing cd command from vyprvpn download script

### DIFF
--- a/openvpn/vyprvpn/configure-openvpn.sh
+++ b/openvpn/vyprvpn/configure-openvpn.sh
@@ -4,41 +4,38 @@
 source /etc/openvpn/utils.sh
 
 if [[ -z "$VPN_PROVIDER_HOME" ]]; then
-   echo "ERROR: Need to have VPN_PROVIDER_HOME set to call this script" && exit 1
+  echo "ERROR: Need to have VPN_PROVIDER_HOME set to call this script" && exit 1
 fi
 
 # Download & extract ovpn files from provider
-URL="https://support.vyprvpn.com/hc/article_attachments/360052617332"
-PACKAGE="Vypr_OpenVPN_20200320.zip"
-OUTPUT="/tmp/VyprVPN.zip"
+baseURL="https://support.vyprvpn.com/hc/article_attachments/360052617332"
+vyprvpn_config_bundle="Vypr_OpenVPN_20200320.zip"
+tmp_file=$(mktemp)
+tmp_dir=$(mktemp -d)
 
 download_extract () {
-  echo "Downloading OpenVPN configs into temporary file ${OUTPUT}"
-  curl -sSL "${URL}/${PACKAGE}" -o "${OUTPUT}"
+  echo "Downloading OpenVPN configs into temporary file ${tmp_file}"
+  curl -sSL "${baseURL}/${vyprvpn_config_bundle}" -o "${tmp_file}"
 
   # Delete all files for VyprVPN provider, except scripts
   find "${VPN_PROVIDER_HOME}" -type f ! -iname "*.sh" -delete
 
-  temp_dir=$(mktemp -d) && export temp_dir
-  echo "Temporarily extracting OpenVPN configs into directory ${temp_dir}"
-  unzip -qq "${OUTPUT}" -d "${temp_dir}"
+  echo "Temporarily extracting OpenVPN configs into directory ${tmp_dir}"
+  unzip -qq "${tmp_file}" -d "${tmp_dir}"
 }
 
 rename_configs () {
   # Automatically renames & moves the OVPN files with the encryption keysize as part of their names
-  cd "${temp_dir}/GF_OpenVPN_20200320" || exit 2
-  for ks in $(find . -maxdepth 1 -type d -iname "OpenVPN*" -print | tr -d '[:alpha:][:punct:]'); do
-    cd "OpenVPN${ks}" || return
-    for f in *.ovpn; do
-      base=$(echo "${f}" | awk -F'.' '{print $1}')
-      ext=$(echo "${f}" | awk -F'.' '{print $2}')
+  for ks in $(find "${tmp_dir}"/GF_OpenVPN_20200320/* -maxdepth 1 -type d -print | awk -F'/' '{print $NF}' | tr -d '[:alpha:][:punct:]'); do
+    for f in "${tmp_dir}/GF_OpenVPN_20200320/OpenVPN${ks}"/*.ovpn; do
+      base=$(echo "${f}" | awk -F'/' '{print $NF}'|  awk -F'.' '{print $1}')
+      ext=$(echo "${f}" | awk -F'/' '{print $NF}' | awk -F'.' '{print $2}')
       nf=$(echo "${base}-${ks}.${ext}")
       sed -i '/keepalive.*/d' "${f}"
       cp "${f}" "${VPN_PROVIDER_HOME}/${nf}"
     done
-    cd ..
   done
-  cp "${temp_dir}"/GF_OpenVPN_20200320/OpenVPN256/ca.vyprvpn.com.crt "${VPN_PROVIDER_HOME}"
+  cp "${tmp_dir}"/GF_OpenVPN_20200320/OpenVPN256/ca.vyprvpn.com.crt "${VPN_PROVIDER_HOME}"
 
   # Select a random server as default.ovpn
   ln -sf "$(find "${VPN_PROVIDER_HOME}" -iname "*.ovpn" | shuf -n 1)" "${VPN_PROVIDER_HOME}/default.ovpn"
@@ -50,7 +47,7 @@ if find "${VPN_PROVIDER_HOME}" -type f ! -iname 'configure-openvpn.sh' | grep -q
 else
   download_extract
   rename_configs
-  echo "Removing ${temp_dir} & ${OUTPUT}"
-  rm -rf "${temp_dir}"
-  rm -f "${OUTPUT}"
+  echo "Removing ${tmp_dir} & ${tmp_file}"
+  rm -rf "${tmp_dir}"
+  rm -f "${tmp_file}"
 fi


### PR DESCRIPTION
<!--
  Please, vpn provider updates should ONLY be done at the new repo:
  https://github.com/haugene/vpn-configs-contrib
  No updates and such will be accepted here
-->
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  Also, please create PRs to DEV branch, !!NOT!! MASTER branch. 
  If necessary, when we review or such, 
  make a comment if you feel this needs to go to master directly, 
  otherwise we will merge to master when necesssary.
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Leave this section emtpy if this PR is NOT a breaking change.
-->
```txt
NA
```


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
```txt
rewrote this script to no longer call the cd command.
```


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to a this container)
- [ ] Breaking change (fix/feature causing existing functionality to break)


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: ```fixes #```
- This PR is related to issue:
  - #1406
  - #1615
  - #1616
- Link to documentation updated (if done separately): ```https://...```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated

<!-- Please check *Preview* before submitting -->

<details>
  <summary>logs</summary>

  ```bash
  22:50 # docker logs -f vpn_test
Creating TUN device /dev/net/tun
Using OpenVPN provider: VYPRVPN
Running with VPN_CONFIG_SOURCE auto
Provider VYPRVPN has a bundled setup script. Defaulting to internal config
Executing setup script for vyprvpn
Downloading OpenVPN configs into temporary file /tmp/tmp.wDWQRGY4eS
Temporarily extracting OpenVPN configs into directory /tmp/tmp.uXG03bPHk1
Removing /tmp/tmp.uXG03bPHk1 & /tmp/tmp.wDWQRGY4eS
Starting OpenVPN using config USA - Austin-256.ovpn
Modifying /etc/openvpn/vyprvpn/USA - Austin-256.ovpn for best behaviour in this container
Modification: Point auth-user-pass option to the username/password file
Modification: Change ca certificate path
Modification: Change ping options
Modification: Update/set resolv-retry to 15 seconds
Modification: Change tls-crypt keyfile path
Modification: Set output verbosity to 3
Modification: Remap SIGUSR1 signal to SIGTERM, avoid OpenVPN restart loop
Setting OpenVPN credentials...
enabling firewall
Firewall is active and enabled on system startup
allowing 172.17.0.0/16 through the firewall to port 9091
Rule added
allowing 172.17.0.0/16 through the firewall to port 8080
Rule added
allowing 172.17.0.0/16 through the firewall to port 9091
Skipping adding existing rule
adding route to local network 192.168.0.0/16 via 172.17.0.1 dev eth0
allowing 192.168.0.0/16 through the firewall to port 9091
Rule added
allowing 192.168.0.0/16 through the firewall to port 8080
Rule added
allowing 192.168.0.0/16 through the firewall to port 9091
Skipping adding existing rule
Sun Apr  3 03:37:13 2022 OpenVPN 2.4.7 x86_64-pc-linux-gnu [SSL (OpenSSL)] [LZO] [LZ4] [EPOLL] [PKCS11] [MH/PKTINFO] [AEAD] built on Mar 22 2022
Sun Apr  3 03:37:13 2022 library versions: OpenSSL 1.1.1f  31 Mar 2020, LZO 2.10
Sun Apr  3 03:37:13 2022 NOTE: the current --script-security setting may allow this configuration to call user-defined scripts
Sun Apr  3 03:37:13 2022 TCP/UDP: Preserving recently used remote address: [AF_INET]209.99.61.18:443
Sun Apr  3 03:37:13 2022 Socket Buffers: R=[212992->212992] S=[212992->212992]
Sun Apr  3 03:37:13 2022 UDP link local: (not bound)
Sun Apr  3 03:37:13 2022 UDP link remote: [AF_INET]209.99.61.18:443
Sun Apr  3 03:37:13 2022 NOTE: UID/GID downgrade will be delayed because of --client, --pull, or --up-delay
Sun Apr  3 03:37:13 2022 TLS: Initial packet from [AF_INET]209.99.61.18:443, sid=a352234d 4ddca5c9
Sun Apr  3 03:37:14 2022 VERIFY OK: depth=2, C=CH, ST=Lucerne, L=Meggen, O=Golden Frog GmbH, CN=Golden Frog GmbH Root CA, emailAddress=admin@goldenfrog.com
Sun Apr  3 03:37:14 2022 VERIFY OK: depth=1, C=CH, ST=Lucerne, L=Meggen, O=Golden Frog GmbH, CN=VyprVPN Intermediate CA, emailAddress=admin@goldenfrog.com
Sun Apr  3 03:37:14 2022 VERIFY X509NAME OK: C=CH, ST=Lucerne, L=Meggen, O=Golden Frog GmbH, CN=us3.vyprvpn.com, emailAddress=admin@goldenfrog.com
Sun Apr  3 03:37:14 2022 VERIFY OK: depth=0, C=CH, ST=Lucerne, L=Meggen, O=Golden Frog GmbH, CN=us3.vyprvpn.com, emailAddress=admin@goldenfrog.com
Sun Apr  3 03:37:14 2022 Control Channel: TLSv1.2, cipher TLSv1.2 ECDHE-RSA-AES256-GCM-SHA384, 4096 bit RSA
Sun Apr  3 03:37:14 2022 [us3.vyprvpn.com] Peer Connection Initiated with [AF_INET]209.99.61.18:443
Sun Apr  3 03:37:15 2022 SENT CONTROL [us3.vyprvpn.com]: 'PUSH_REQUEST' (status=1)
Sun Apr  3 03:37:16 2022 PUSH: Received control message: 'PUSH_REPLY,redirect-gateway def1 bypass-dhcp,dhcp-option DNS 10.2.14.1,explicit-exit-notify 5,rcvbuf 524288,route-gateway 10.2.14.1,topology subnet,ping 10,ping-restart 60,ifconfig 10.2.14.172 255.255.255.0,peer-id 3,cipher AES-256-GCM'
Sun Apr  3 03:37:16 2022 OPTIONS IMPORT: timers and/or timeouts modified
Sun Apr  3 03:37:16 2022 OPTIONS IMPORT: explicit notify parm(s) modified
Sun Apr  3 03:37:16 2022 OPTIONS IMPORT: --sndbuf/--rcvbuf options modified
Sun Apr  3 03:37:16 2022 Socket Buffers: R=[212992->1048576] S=[212992->212992]
Sun Apr  3 03:37:16 2022 OPTIONS IMPORT: --ifconfig/up options modified
Sun Apr  3 03:37:16 2022 OPTIONS IMPORT: route options modified
Sun Apr  3 03:37:16 2022 OPTIONS IMPORT: route-related options modified
Sun Apr  3 03:37:16 2022 OPTIONS IMPORT: --ip-win32 and/or --dhcp-option options modified
Sun Apr  3 03:37:16 2022 OPTIONS IMPORT: peer-id set
Sun Apr  3 03:37:16 2022 OPTIONS IMPORT: adjusting link_mtu to 1625
Sun Apr  3 03:37:16 2022 OPTIONS IMPORT: data channel crypto options modified
Sun Apr  3 03:37:16 2022 Data Channel: using negotiated cipher 'AES-256-GCM'
Sun Apr  3 03:37:16 2022 Outgoing Data Channel: Cipher 'AES-256-GCM' initialized with 256 bit key
Sun Apr  3 03:37:16 2022 Incoming Data Channel: Cipher 'AES-256-GCM' initialized with 256 bit key
Sun Apr  3 03:37:16 2022 ROUTE_GATEWAY 172.17.0.1/255.255.0.0 IFACE=eth0 HWADDR=02:42:ac:11:00:03
Sun Apr  3 03:37:16 2022 TUN/TAP device tun0 opened
Sun Apr  3 03:37:16 2022 TUN/TAP TX queue length set to 100
Sun Apr  3 03:37:16 2022 /sbin/ip link set dev tun0 up mtu 1500
Sun Apr  3 03:37:16 2022 /sbin/ip addr add dev tun0 10.2.14.172/24 broadcast 10.2.14.255
Sun Apr  3 03:37:16 2022 /sbin/ip route add 209.99.61.18/32 via 172.17.0.1
Sun Apr  3 03:37:16 2022 /sbin/ip route add 0.0.0.0/1 via 10.2.14.1
Sun Apr  3 03:37:16 2022 /sbin/ip route add 128.0.0.0/1 via 10.2.14.1
Up script executed with device=tun0 ifconfig_local=10.2.14.172
Updating TRANSMISSION_BIND_ADDRESS_IPV4 to the ip of tun0 : 10.2.14.172

-------------------------------------
Transmission will run as
-------------------------------------
User name:   root
User uid:    0
User gid:    0
-------------------------------------

Updating Transmission settings.json with values from env variables
Attempting to use existing settings.json for Transmission
Could not read existing settings.json. Generating settings.json for Transmission from environment and defaults /etc/transmission/default-settings.json
Overriding bind-address-ipv4 because TRANSMISSION_BIND_ADDRESS_IPV4 is set to 10.2.14.172
Overriding download-dir because TRANSMISSION_DOWNLOAD_DIR is set to /data/completed
Overriding incomplete-dir because TRANSMISSION_INCOMPLETE_DIR is set to /data/incomplete
Overriding rpc-password because TRANSMISSION_RPC_PASSWORD is set to [REDACTED]
Overriding rpc-port because TRANSMISSION_RPC_PORT is set to 9091
Overriding rpc-username because TRANSMISSION_RPC_USERNAME is set to
Overriding watch-dir because TRANSMISSION_WATCH_DIR is set to /data/watch
sed'ing True to true
STARTING TRANSMISSION
Transmission startup script complete.
Sun Apr  3 03:37:16 2022 GID set to abc
Sun Apr  3 03:37:16 2022 UID set to abc
Sun Apr  3 03:37:16 2022 Initialization Sequence Completed
```

</details>
