### PR TITLE
Fix bitwise decimal & octal

### DIFF
--- a/transmission/userSetup.sh
+++ b/transmission/userSetup.sh
@@ -44,17 +44,26 @@ if [ -n "$PUID" ] && [ ! "$(id -u root)" -eq "$PUID" ]; then
             "${TRANSMISSION_WATCH_DIR}"
 
         echo "Setting permissions for download and incomplete directories"
-        TRANSMISSION_UMASK_OCTAL=$(printf '%03g' $(printf '%o\n' $(jq .umask ${TRANSMISSION_HOME}/settings.json)))
-        DIR_PERMS=$(printf '%o\n' $((0777 & ~TRANSMISSION_UMASK_OCTAL)))
-        FILE_PERMS=$(printf '%o\n' $((0666 & ~TRANSMISSION_UMASK_OCTAL)))
-        echo "Mask: ${TRANSMISSION_UMASK_OCTAL}"
+        
+        if [ -z "$TRANSMISSION_UMASK" ] ; then
+            # fetch from settings.json if not defined in environment
+            # because updateSettings.py is called after this script is run
+            TRANSMISSION_UMASK=$(jq .umask ${TRANSMISSION_HOME}/settings.json)
+        fi
+
+        TRANSMISSION_UMASK_OCTAL=$( printf "%o\n" "$TRANSMISSION_UMASK" )
+
+        DIR_PERMS=$( printf '%o\n' $(( 8#777 & ~TRANSMISSION_UMASK)) )
+        FILE_PERMS=$( printf '%o\n' $(( 8#666 & ~TRANSMISSION_UMASK)) )
+        
+        echo "umask: ${TRANSMISSION_UMASK_OCTAL}"
         echo "Directories: ${DIR_PERMS}"
         echo "Files: ${FILE_PERMS}"
 
         find "${TRANSMISSION_DOWNLOAD_DIR}" "${TRANSMISSION_INCOMPLETE_DIR}" -type d \
-        -exec chmod $(printf '%o\n' $((0777 & ~TRANSMISSION_UMASK_OCTAL))) {} +
+        -exec chmod "$DIR_PERMS" {} +
         find "${TRANSMISSION_DOWNLOAD_DIR}" "${TRANSMISSION_INCOMPLETE_DIR}" -type  f \
-        -exec chmod $(printf '%o\n' $((0666 & ~TRANSMISSION_UMASK_OCTAL))) {} +
+        -exec chmod "$FILE_PERMS" {} +
 
         echo "Setting permission for watch directory (775) and its files (664)"
         chmod -R o=rX,ug=rwX \

--- a/transmission/userSetup.sh
+++ b/transmission/userSetup.sh
@@ -51,7 +51,7 @@ if [ -n "$PUID" ] && [ ! "$(id -u root)" -eq "$PUID" ]; then
             TRANSMISSION_UMASK=$(jq .umask ${TRANSMISSION_HOME}/settings.json)
         fi
 
-        TRANSMISSION_UMASK_OCTAL=$( printf "%o\n" "$TRANSMISSION_UMASK" )
+        TRANSMISSION_UMASK_OCTAL=$( printf "%o\n" "${TRANSMISSION_UMASK}" )
 
         DIR_PERMS=$( printf '%o\n' $(( 8#777 & ~TRANSMISSION_UMASK)) )
         FILE_PERMS=$( printf '%o\n' $(( 8#666 & ~TRANSMISSION_UMASK)) )

--- a/transmission/userSetup.sh
+++ b/transmission/userSetup.sh
@@ -61,9 +61,9 @@ if [ -n "$PUID" ] && [ ! "$(id -u root)" -eq "$PUID" ]; then
         echo "Files: ${FILE_PERMS}"
 
         find "${TRANSMISSION_DOWNLOAD_DIR}" "${TRANSMISSION_INCOMPLETE_DIR}" -type d \
-        -exec chmod "$DIR_PERMS" {} +
+        -exec chmod "${DIR_PERMS}" {} +
         find "${TRANSMISSION_DOWNLOAD_DIR}" "${TRANSMISSION_INCOMPLETE_DIR}" -type  f \
-        -exec chmod "$FILE_PERMS" {} +
+        -exec chmod "${FILE_PERMS}" {} +
 
         echo "Setting permission for watch directory (775) and its files (664)"
         chmod -R o=rX,ug=rwX \


### PR DESCRIPTION
<!--
  Please, vpn provider updates should ONLY be done at the new repo:
  https://github.com/haugene/vpn-configs-contrib
  No updates and such will be accepted here
-->
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  Also, please create PRs to DEV branch, !!NOT!! MASTER branch. 
  If necessary, when we review or such, 
  make a comment if you feel this needs to go to master directly, 
  otherwise, we will merge to master when necessary.
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Leave this section empty if this PR is NOT a breaking change.
-->
```txt
<placeholder>
```


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
```txt
Fix bitwise decimal & octal
```


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this container)
- [ ] Breaking change (fix/feature causing existing functionality to break)


## Additional information
<!--
  Details are important, and help maintainers process your PR.
  Please be sure to fill out additional details, if applicable.
-->

Also uses the TRASNMSISSION_UMASK variable instead of settings.json since updateSettings.py is called after userSetup.sh causing the TRANSMISSION_UMASK in settings.json to be stale when userSetup.sh accesses it.

- This PR fixes or closes issue: fixes #2450 
- This PR is related to issue: ```relates to #```
- Link to documentation updated (if done separately): ```https://...```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated

<!-- Please check *Preview* before submitting -->
