### PR TITLE
Simplify RPC creds setup

### DIFF
--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -197,17 +197,11 @@ else
 fi
 
 if [[ -f /run/secrets/rpc_creds ]]; then
-  #write creds if no file or contents are not the same.
-  if [[ ! -f /config/transmission-credentials.txt ]] || [[ "$(cat /run/secrets/rpc_creds)" != "$(cat /config/transmission-credentials.txt)" ]]; then
-    echo "Setting Transmission RPC credentials from docker secret..."
-    cp /run/secrets/rpc_creds /config/transmission-credentials.txt
-    export TRANSMISSION_RPC_USERNAME=$(head -1 /config/transmission-credentials.txt)
-    export TRANSMISSION_RPC_PASSWORD=$(tail -1 /config/transmission-credentials.txt)
-  fi
-else
-  echo "${TRANSMISSION_RPC_USERNAME}" > /config/transmission-credentials.txt
-  echo "${TRANSMISSION_RPC_PASSWORD}" >> /config/transmission-credentials.txt
+  export TRANSMISSION_RPC_USERNAME=$(head -1 /run/secrets/rpc_creds)
+  export TRANSMISSION_RPC_PASSWORD=$(tail -1 /run/secrets/rpc_creds)
 fi
+echo "${TRANSMISSION_RPC_USERNAME}" > /config/transmission-credentials.txt
+echo "${TRANSMISSION_RPC_PASSWORD}" >> /config/transmission-credentials.txt
 
 # Persist transmission settings for use by transmission-daemon
 export CONFIG="${CHOSEN_OPENVPN_CONFIG}"


### PR DESCRIPTION
Reduce the complexity associated with creating RPC creds

<!--
  Please, vpn provider updates should ONLY be done at the new repo:
  https://github.com/haugene/vpn-configs-contrib
  No updates and such will be accepted here
-->
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  Also, please create PRs to DEV branch, !!NOT!! MASTER branch. 
  If necessary, when we review or such, 
  make a comment if you feel this needs to go to master directly, 
  otherwise, we will merge to master when necessary.
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Leave this section empty if this PR is NOT a breaking change.
-->
```txt
<placeholder>
```


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
```txt
Simplify and fix RPC creds set up with docker secrets.
```


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this container)
- [ ] Breaking change (fix/feature causing existing functionality to break)


## Additional information
<!--
  Details are important, and help maintainers process your PR.
  Please be sure to fill out additional details, if applicable.
-->
The current integration with docker secrets is flakey/overcomplicated.

For example in the case where there is an `rpc_creds` docker secret, which is the same as `transmission-credentials.txt` the environment variables won't be set to the correct credentials.

This pull requests, not only fixes that issue, but drastically reduces the complexity of the code.

If `rpc_creds` exists, its content will **always** be used as environment variables.
Environment variables are **always** written into the `transmission-credentials.txt` file.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated

<!-- Please check *Preview* before submitting -->
