### PR TITLE
Fix crash in fetch-external-configs on unset vars

### DIFF
--- a/openvpn/fetch-external-configs.sh
+++ b/openvpn/fetch-external-configs.sh
@@ -18,18 +18,19 @@ if [[ "${VPN_CONFIG_SOURCE_TYPE}" == "github_zip" ]]; then
     echo "Cleanup: deleting ${config_repo_temp_zip_file} and ${config_repo_temp_dir}"
     rm -rf "${config_repo_temp_zip_file}" "${config_repo_temp_dir}"
   }
+
+  config_repo_temp_zip_file=$(mktemp)
+  config_repo_temp_dir=$(mktemp -d)
   trap cleanup EXIT
 
   # Concatenate URL for config bundle from the given GitHub repo
   GITHUB_CONFIG_BUNDLE_URL="https://github.com/${GITHUB_CONFIG_SOURCE_REPO}/archive/${GITHUB_CONFIG_SOURCE_REVISION}.zip"
   
   # Create a temporary file and download bundle to it
-  config_repo_temp_zip_file=$(mktemp)
   echo "Downloading configs from ${GITHUB_CONFIG_BUNDLE_URL} into ${config_repo_temp_zip_file}"
   curl -sSL --fail -o "${config_repo_temp_zip_file}" "${GITHUB_CONFIG_BUNDLE_URL}"
 
   # Create a temporary folder and extract configs there
-  config_repo_temp_dir=$(mktemp -d)
   echo "Extracting configs to ${config_repo_temp_dir}"
   unzip -q "${config_repo_temp_zip_file}" -d "${config_repo_temp_dir}"
 


### PR DESCRIPTION
<!--
  Please, vpn provider updates should ONLY be done at the new repo:
  https://github.com/haugene/vpn-configs-contrib
  No updates and such will be accepted here
-->
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  Also, please create PRs to DEV branch, !!NOT!! MASTER branch. 
  If necessary, when we review or such, 
  make a comment if you feel this needs to go to master directly, 
  otherwise, we will merge to master when necessary.
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Leave this section empty if this PR is NOT a breaking change.
-->
```txt
```


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
```txt
Fix a crasher that obscures another problem. If curl to get configs fails, there is an error in cleaning up.

./etc/openvpn/fetch-external-configs.sh: line 16: config_repo_temp_dir: unbound variable
```


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this container)
- [ ] Breaking change (fix/feature causing existing functionality to break)


## Additional information
<!--
  Details are important, and help maintainers process your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: ```fixes #```
- This PR is related to issue: ```relates to #```
- Link to documentation updated (if done separately): ```https://...```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated

<!-- Please check *Preview* before submitting -->
