### PR TITLE
OVPN script fix for for 4.x branch 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 .git
+.github

--- a/.github/workflows/image-build-template-workflow.yml
+++ b/.github/workflows/image-build-template-workflow.yml
@@ -49,7 +49,7 @@ jobs:
 
       # Finally, build and push the images
       - name: Build image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: ${{ inputs.build-context }}
           platforms: linux/arm,linux/arm64,linux/amd64

--- a/docs/tips-tricks.md
+++ b/docs/tips-tricks.md
@@ -212,3 +212,9 @@ $ sudo systemctl start transmission-openvpn.service
 
 A working example of running this container behind a traefik reverse proxy can be found here:
 [Config](https://github.com/haugene/docker-transmission-openvpn/issues/1763#issuecomment-844404143)
+
+#### Running this container with Podman
+
+The `podman run` command is almost identical to [the one mentioned in README.md](../README.md#docker-run) but with the following exception:
+
+Instead `--cap-add=NET_ADMIN` you have to specify `--cap-add=NET_ADMIN,NET_RAW,MKNOD`. `MKNOD` and `NET_ADMIN` are necessary so Podman can create the tunnel, `NET_RAW` is needed for `ping`.

--- a/docs/tips-tricks.md
+++ b/docs/tips-tricks.md
@@ -1,16 +1,17 @@
-#### Use Google DNS servers
+# Use Google DNS servers
 Some have encountered problems with DNS resolving inside the docker container.
 This causes trouble because OpenVPN will not be able to resolve the host to connect to.
 If you have this problem use Docker's --dns flag and try using Google's DNS servers by
 adding --dns 8.8.8.8 --dns 8.8.4.4 as parameters to the usual run command.
 
-#### Restart the container if the connection is lost
+# Restart the container if the connection is lost
 If the VPN connection fails or the container for any other reason loses connectivity, you want it to recover from it. One way of doing this is to set the environment variable `OPENVPN_OPTS=--inactive 3600 --ping 10 --ping-exit 60` and use the --restart=always flag when starting the container. This way OpenVPN will exit if ping fails over a period of time which will stop the container and then the Docker daemon will restart it.
 
-#### Let other containers use the VPN
+# Let other containers use the VPN
 
 To let other containers use VPN you have to add them to the same Service network as your VPN container runs, you can do this by adding `network_mode: "service:transmission-openvpn"`. Additionally, you have to set `depends_on` to the `transmission-openvpn` service to let docker-compose know that your new container should start **after** `transmission-openvpn` is up and running. As the final step, you can add `healthcheck` to your service.
 
+## Example (Jackett):
 As an example, let's add [Jackett](https://github.com/linuxserver/docker-jackett) to the `transmission-openvpn` network based on the example from [Running the container](run-container.md):
 
 ```yaml
@@ -64,7 +65,7 @@ services:
             retries: 2
 ```
 
-##### Check if the container is using VPN
+### Check if the container is using VPN
 
 After the container starts, simply call `curl` under it to check your IP address, for example with Jackett you should see your VPN IP address as output:
 
@@ -82,13 +83,65 @@ Server: Kestrel
 Location: /UI/Dashboard
 ```
 
-#### Reach sleep or hibernation on your host if no torrents are active
+## Example (Dante):
+As an example, let's add [Dante](https://www.inet.no/dante/) socks5 proxy to the `transmission-openvpn` network based on the example from [Running the container](run-container.md):
+
+```yaml
+version: '3.3'
+services:
+    transmission-openvpn:
+        cap_add:
+            - NET_ADMIN
+        volumes:
+            - '/your/storage/path/:/data'
+        environment:
+            - OPENVPN_PROVIDER=PIA
+            - OPENVPN_CONFIG=france
+            - OPENVPN_USERNAME=user
+            - OPENVPN_PASSWORD=pass
+            - LOCAL_NETWORK=192.168.0.0/16
+        logging:
+            driver: json-file
+            options:
+                max-size: 10m
+        ports:
+            - '9091:9091'
+            - '1080:1080'  # This is Dante Socks5 Port – managed by VPN Service Network
+        restart: unless-stopped
+        image: haugene/transmission-openvpn
+
+    socks5-proxy:
+        image: wernight/dante
+        restart: unless-stopped
+        network_mode: service:transmission-openvpn
+        depends_on:
+            - transmission-openvpn
+        command:
+            - /bin/sh
+            - -c
+            - |
+                echo "Waiting for VPN to connect . . ."
+                while ! ip link show tun0 >/dev/null 2>&1 || ! ip link show tun0 | grep -q "UP"; do sleep 1; done
+                echo "VPN connected. Starting proxy service . . ."
+                sed -i 's/^\(external:\).*/\1 tun0/' /etc/sockd.conf
+                sockd
+```
+
+### Test Dante socks5 proxy
+```bash
+curl -x socks5h://{docker-host-ip}:1080 http://ip.ip-check.net
+```
+
+### Bonus socks5 tip
+With the [Proxy SwitchyOmega](https://chrome.google.com/webstore/detail/proxy-switchyomega/padekgcemlokbadohgkifijomclgjgif) Chrome/Edge extension, you can configure specific websites on your local machine to route through your socks5 proxy server.
+
+# Reach sleep or hibernation on your host if no torrents are active
 By default, Transmission will always [scrape](https://en.wikipedia.org/wiki/Tracker_scrape) trackers, even if all torrents have completed their activities, or they have been paused manually. This will cause Transmission to be always active, therefore never allow your host server to be inactive and go to sleep/hibernation/whatever. If this is something you want, you can add the following variable when creating the container. It will turn off a hidden setting in Transmission which will stop the application to scrape trackers for paused torrents. Transmission will become inactive, and your host will reach the desired state.
 ```bash
 -e "TRANSMISSION_SCRAPE_PAUSED_TORRENTS_ENABLED=false"
 ```
 
-#### Running it on a NAS
+# Running it on a NAS
 Several popular NAS platforms support Docker containers. You should be able to set up
 and configure this container using their web interfaces. As of version 3.0 of this image
 creates a TUN interface inside the container by default. This previously had to be mounted
@@ -100,7 +153,7 @@ for the NAS. This should set up the device and you can mount it.
 There are some issues involved in running it on Synology NAS, 
 Please see this issue that discusses [solutions](https://github.com/haugene/docker-transmission-openvpn/issues/1542#issuecomment-793605649)
 
-#### Systemd Integration
+# Systemd Integration
 On many modern Linux systems, including Ubuntu, systemd can be used to start the transmission-openvpn at boot time, and restart it after any failure.
 
 Save the following as `/etc/systemd/system/transmission-openvpn.service`, and replace the OpenVPN PROVIDER/USERNAME/PASSWORD directives with your settings, and add any other directives that you're using.
@@ -155,7 +208,7 @@ $ sudo systemctl stop transmission-openvpn.service
 # Later ...
 $ sudo systemctl start transmission-openvpn.service
 ```
-#### Running with Traefik reverse proxy
+# Running with Traefik reverse proxy
 
 A working example of running this container behind a traefik reverse proxy can be found here:
 [Config](https://github.com/haugene/docker-transmission-openvpn/issues/1763#issuecomment-844404143)

--- a/openvpn/ovpn/configure-openvpn.sh
+++ b/openvpn/ovpn/configure-openvpn.sh
@@ -46,11 +46,18 @@ echo "Downloading OpenVPN config bundle into temporary file $tmp_file"
 #unzip /tmp/main.zip "vpn-configs-contrib-main/openvpn/ovpn/*" -d /tmp/
 #mv /tmp/vpn-configs-contrib-main/openvpn/ovpn/* /etc/openvpn/ovpn
 #rm /tmp/vpn-configs-contrib-main/openvpn/ovpn/ -R
+#rm /tmp/main.zip
 
-cd /tmp/
+
+echo "creating temp folder"
+mkdir /tmp/ovpnxtract/
+echo "entering temp folder"
+cd /tmp/ovpnxtract/
 git clone https://github.com/haugene/vpn-configs-contrib.git 
-mv /tmp/vpn-configs-contrib-main/openvpn/ovpn/* /etc/openvpn/ovpn
-rm /tmp/vpn-configs-contrib-main/ -R
+echo "moving content"
+mv /tmp/ovpnxtract/vpn-configs-contrib/openvpn/ovpn/* /etc/openvpn/ovpn
+echo "deleting temp folder"
+rm -rf /tmp/ovpnxtract/
 
 #rm /tmp/vpn-configs-contrib-main/
 
@@ -60,7 +67,6 @@ rm /tmp/vpn-configs-contrib-main/ -R
 #mv /tmp/vpn-configs-contrib-ovpnwork-main/openvpn/ovpn/* /etc/openvpn/ovpn
 #rm /tmp/vpn-configs-contrib-ovpnwork-main/openvpn/ovpn/ -R
 
-rm /tmp/main.zip
 
 
 #pattern=$OVPN_CONNECTION.$OVPN_COUNTRY.$OVPN_CITY.$OVPN_PROTOCOL

--- a/openvpn/ovpn/configure-openvpn.sh
+++ b/openvpn/ovpn/configure-openvpn.sh
@@ -41,11 +41,18 @@ echo "Downloading OpenVPN config bundle into temporary file $tmp_file"
 #svn not baked into docker, leave for another day
 #svn export https://github.com/haugene/vpn-configs-contrib/tree/main/openvpn/"
 
-wget -c https://github.com/haugene/vpn-configs-contrib/archive/refs/heads/main.zip  -P /tmp/
-echo "Extract OpenVPN config bundle into $VPN_PROVIDER_HOME"
-unzip /tmp/main.zip "vpn-configs-contrib-main/openvpn/ovpn/*" -d /tmp/
+#wget -c https://github.com/haugene/vpn-configs-contrib/archive/refs/heads/main.zip  -P /tmp/
+#echo "Extract OpenVPN config bundle into $VPN_PROVIDER_HOME"
+#unzip /tmp/main.zip "vpn-configs-contrib-main/openvpn/ovpn/*" -d /tmp/
+#mv /tmp/vpn-configs-contrib-main/openvpn/ovpn/* /etc/openvpn/ovpn
+#rm /tmp/vpn-configs-contrib-main/openvpn/ovpn/ -R
+
+cd /tmp/
+git clone https://github.com/haugene/vpn-configs-contrib.git 
 mv /tmp/vpn-configs-contrib-main/openvpn/ovpn/* /etc/openvpn/ovpn
-rm /tmp/vpn-configs-contrib-main/openvpn/ovpn/ -R
+rm /tmp/vpn-configs-contrib-main/ -R
+
+#rm /tmp/vpn-configs-contrib-main/
 
 #test repo
 #wget -c https://github.com/derekcentrico/vpn-configs-contrib-ovpnwork/archive/refs/heads/main.zip -P /tmp/


### PR DESCRIPTION
At some point very recently something broke for users where unzip does not function anymore.  I'm wondering if it has to do with the ZIP function on Github changing.  

At any rate, I hacked up the script to use GIT CLONE now and it works on my test build of 4.x.

Cite issues:  https://github.com/haugene/docker-transmission-openvpn/issues/2565