### PR TITLE
Update dev

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 .git
+.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,10 @@ ADD transmission/ /etc/transmission/
 ADD scripts /etc/scripts/
 ADD privoxy/scripts /opt/privoxy/
 
+# Support legacy IPTables commands
+RUN update-alternatives --set iptables $(which iptables-legacy) && \
+    update-alternatives --set ip6tables $(which ip6tables-legacy)
+
 ENV OPENVPN_USERNAME=**None** \
     OPENVPN_PASSWORD=**None** \
     OPENVPN_PROVIDER=**None** \

--- a/docs/supported-providers.md
+++ b/docs/supported-providers.md
@@ -130,12 +130,12 @@ Compose sample:
             - OPENVPN_PASSWORD=pass
 ```
 
-### If you only need to mount one file
+### Do not mount single config file
 
-You might not need to mount a folder of configs. You may just have one config file you want to use.
-In that case, you can just mount it directly. Mounting it as `default.ovpn` will let you omit `OPENVPN_CONFIG` as well.
+Do not mount a single config directly. The container will fail if you try, since it causes sed errors when modify-openvpn-config.sh is executed.
+Instead mount the directory where the config exists.
 
-Compose sample:
+```bash
+sed: cannot rename /etc/openvpn/custom/sedHeF3gS: Device or resource busy
 ```
-             - /volume1/docker/ipvanish/my-preferred-config-file.ovpn:/etc/openvpn/custom/default.ovpn
-```
+

--- a/openvpn/fetch-external-configs.sh
+++ b/openvpn/fetch-external-configs.sh
@@ -18,18 +18,19 @@ if [[ "${VPN_CONFIG_SOURCE_TYPE}" == "github_zip" ]]; then
     echo "Cleanup: deleting ${config_repo_temp_zip_file} and ${config_repo_temp_dir}"
     rm -rf "${config_repo_temp_zip_file}" "${config_repo_temp_dir}"
   }
+
+  config_repo_temp_zip_file=$(mktemp)
+  config_repo_temp_dir=$(mktemp -d)
   trap cleanup EXIT
 
   # Concatenate URL for config bundle from the given GitHub repo
   GITHUB_CONFIG_BUNDLE_URL="https://github.com/${GITHUB_CONFIG_SOURCE_REPO}/archive/${GITHUB_CONFIG_SOURCE_REVISION}.zip"
   
   # Create a temporary file and download bundle to it
-  config_repo_temp_zip_file=$(mktemp)
   echo "Downloading configs from ${GITHUB_CONFIG_BUNDLE_URL} into ${config_repo_temp_zip_file}"
   curl -sSL --fail -o "${config_repo_temp_zip_file}" "${GITHUB_CONFIG_BUNDLE_URL}"
 
   # Create a temporary folder and extract configs there
-  config_repo_temp_dir=$(mktemp -d)
   echo "Extracting configs to ${config_repo_temp_dir}"
   unzip -q "${config_repo_temp_zip_file}" -d "${config_repo_temp_dir}"
 

--- a/openvpn/modify-openvpn-config.sh
+++ b/openvpn/modify-openvpn-config.sh
@@ -19,7 +19,7 @@ CONFIG_MOD_CA_CERTS=${CONFIG_MOD_CA_CERTS:-"1"}
 CONFIG_MOD_PING=${CONFIG_MOD_PING:-"1"}
 CONFIG_MOD_RESOLV_RETRY=${CONFIG_MOD_RESOLV_RETRY:-"1"}
 CONFIG_MOD_TLS_CERTS=${CONFIG_MOD_TLS_CERTS:-"1"}
-CONFIG_MOD_VERBOSITY=${CONFIG_MOD_VERBOSITY:-"1"}
+CONFIG_MOD_VERBOSITY=${CONFIG_MOD_VERBOSITY:-"3"}
 CONFIG_MOD_REMAP_USR1=${CONFIG_MOD_REMAP_USR1:-"1"}
 CONFIG_MOD_FAILURE_SCRIPT=${CONFIG_MOD_FAILURE_SCRIPT:-"1"}
 
@@ -81,14 +81,17 @@ if [[ $CONFIG_MOD_TLS_CERTS == "1" ]]; then
 fi
 
 ## Option 6 - Update or set verbosity of openvpn logging
-if [[ $CONFIG_MOD_VERBOSITY == "1" ]]; then
-    echo "Modification: Set output verbosity to 3"
+if [[ $(( "$CONFIG_MOD_VERBOSITY" )) -gt 0 ]]; then
+    if [[ $(( "$CONFIG_MOD_VERBOSITY" )) -gt 9 ]]; then
+        CONFIG_MOD_VERBOSITY=9
+    fi
+    echo "Modification: Set output verbosity to ${CONFIG_MOD_VERBOSITY}"
     # Remove any old options
     sed -i "/^verb.*$/d" "$CONFIG"
 
     # Add new ones
     sed -i "\$q" "$CONFIG" # Ensure config ends with a line feed
-    echo "verb 3" >> "$CONFIG"
+    echo "verb ${CONFIG_MOD_VERBOSITY}" >> "$CONFIG"
 fi
 
 ## Option 7 - Remap the SIGUSR1 signal to SIGTERM

--- a/openvpn/nordvpn/configure-openvpn.sh
+++ b/openvpn/nordvpn/configure-openvpn.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # get config name based on api recommendation + ENV Vars (NORDVPN_COUNTRY, NORDVPN_PROTOCOL, NORDVPN_CATEGORY)
 #
@@ -22,18 +22,38 @@
 set -e -u -o pipefail
 
 #Variables
-MAIN_DIR="${0%/*}/.."
+MAIN_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"/.."
 [[ -f ${MAIN_DIR}/utils.sh ]] && source ${MAIN_DIR}/utils.sh || true
+source ${MAIN_DIR}/utils.sh
+echo $MAIN_DIR
 nordvpn_api="https://api.nordvpn.com"
 nordvpn_dl=downloads.nordcdn.com
 nordvpn_cdn="https://${nordvpn_dl}/configs/files"
 nordvpn_doc="https://haugene.github.io/docker-transmission-openvpn/provider-specific/#nordvpn"
 possible_protocol="tcp, udp"
 VPN_PROVIDER_HOME=${VPN_PROVIDER_HOME:-${MAIN_DIR}/nordvpn}
-NORDVPN_COUNTRY=${NORDVPN_COUNTRY:-""}
-NORDVPN_CATEGORY=${NORDVPN_CATEGORY:-""}
-NORDVPN_PROTOCOL=${NORDVPN_PROTOCOL:-""}
-NORDVPN_SERVER=${NORDVPN_SERVER:-""}
+NORDVPN_TESTS=${NORDVPN_TESTS:-''}
+
+#remove stored files older than 1 day.
+find /tmp -type f -iname json_* -mtime +1 -exec ls -al {} \; -delete 2>/dev/null || true
+#store json between runs to prevent being blocked by api when testing
+if [[ -f  /tmp/json_countries ]] && [[ -n ${NORDVPN_TESTS} ]]; then
+  for i in json_countries json_groups json_technologies
+  do
+    declare "${i}=$(</tmp/${i})"
+  done
+  else
+  #Nordvpn has a fetch limit, storing json to prevent hitting the limit.
+  json_countries=$(curl -s ${nordvpn_api}/v1/servers/countries)
+  #groups used for NORDVPN_CATEGORY
+  json_groups=$(curl -s ${nordvpn_api}/v1/servers/groups)
+  #technologies (NORDVPN_PROTOCOL) not used as only openvpn_udp and openvpn_tcp are tested.
+  json_technologies=$(curl -s ${nordvpn_api}/v1/technologies)
+  for i in json_countries json_groups json_technologies
+  do
+    echo ${!i} > /tmp/${i}
+  done
+fi
 
 # Functions
 # TESTS: set values to test API response.
@@ -41,14 +61,16 @@ test1NoValues() {
   export NORDVPN_COUNTRY=''
   export NORDVPN_PROTOCOL=''
   export NORDVPN_CATEGORY=''
-  log "expected <your country code><NN>.nordvpn.com.ovpn with openvpn_udp"
+  log "expected <your country code><NN>.nordvpn.com with openvpn_tcp"
+  export NORDVPN_REG="[a-z]{2}[0-9]+.nordvpn.com"
 }
 
 test2NoCategory() {
   export NORDVPN_COUNTRY='EE'
-  export NORDVPN_PROTOCOL='tcp'
+  export NORDVPN_PROTOCOL='udp'
   export NORDVPN_CATEGORY=''
-  log "TESTS: expected ee<NN>.nordvpn.com.ovpn with openvpn_tcp"
+  log "TESTS: expected ee<NN>.nordvpn.com with openvpn_udp"
+  export NORDVPN_REG="ee[0-9]+.nordvpn.com"
 }
 
 test3Incompatible_combinations() {
@@ -56,6 +78,7 @@ test3Incompatible_combinations() {
   export NORDVPN_PROTOCOL='openvpn_tcp_tls_crypt'
   export NORDVPN_CATEGORY='legacy_obfuscated_servers'
   log "TESTS: expected a config file not respecting country filter. + message: Unable to find a server with the specified parameters, using any recommended server"
+  export NORDVPN_REG="[a-z]{2}[0-9]+.nordvpn.com"
 }
 
 test4ServerName_given() {
@@ -65,6 +88,7 @@ test4ServerName_given() {
   #get first server from US (228) with tcp
   export NORDVPN_SERVER=$(curl -s 'https://api.nordvpn.com/v1/servers/recommendations?filters\[country_id\]=228&filters\[servers_technologies\]\[identifier\]=openvpn_tcp&limit=1' | jq -r .[].hostname)
   log "TESTS: expected a config file for server ${NORDVPN_SERVER}"
+  export NORDVPN_REG="us[0-9]+.nordvpn.com"
 }
 
 # Normal run functions
@@ -79,10 +103,12 @@ script_init() {
 }
 
 country_filter() {
+  NORDVPN_COUNTRY=${NORDVPN_COUNTRY:-""}
   local nordvpn_api=$1 country=(${NORDVPN_COUNTRY//[;,]/ })
+  local country_id
   if [[ ${#country[@]} -ge 1 ]]; then
     country=${country[0]//_/ }
-    local country_id=$(echo ${json_countries} | jq --raw-output ".[] |
+    country_id=$(echo ${json_countries} | jq --raw-output ".[] |
                           select( (.name|test(\"^${country}$\";\"i\")) or
                                   (.code|test(\"^${country}$\";\"i\")) ) |
                           .id" | head -n 1)
@@ -96,10 +122,12 @@ country_filter() {
 }
 
 group_filter() {
+  NORDVPN_CATEGORY=${NORDVPN_CATEGORY:-""}
   local nordvpn_api=$1 category=(${NORDVPN_CATEGORY//[;,]/ })
+  local identifier=''
   if [[ ${#category[@]} -ge 1 ]]; then
     #category=${category[0]//_/ }
-    local identifier=$(echo $json_groups | jq --raw-output ".[] |
+    identifier=$(echo $json_groups | jq --raw-output ".[] |
                           select( ( .identifier|test(\"${category}\";\"i\")) or
                                   ( .title| test(\"${category}\";\"i\")) ) |
                           .identifier" | head -n 1)
@@ -114,6 +142,7 @@ group_filter() {
 
 technology_filter() {
   local identifier
+  NORDVPN_PROTOCOL=${NORDVPN_PROTOCOL:-tcp}
   if [[ ${NORDVPN_PROTOCOL,,} =~ .*udp.* ]]; then
     identifier="openvpn_udp"
   elif [[ ${NORDVPN_PROTOCOL,,} =~ .*tcp.* ]]; then
@@ -146,30 +175,27 @@ select_hostname() { #TODO return multiples
   else
     load=$(curl -s ${nordvpn_api}/server/stats/${hostname} | jq .percent)
     log "INFO: OVPN: Best server : ${hostname}, load: ${load}"
-    echo ${hostname}
   fi
+
+  log "Best server : ${hostname}"
+  echo ${hostname}
 }
 download_hostname() {
+  NORDVPN_PROTOCOL=${NORDVPN_PROTOCOL:-"tcp"}
   #udp ==> https://downloads.nordcdn.com/configs/files/ovpn_udp/servers/nl601.nordvpn.com.udp.ovpn
   #tcp ==> https://downloads.nordcdn.com/configs/files/ovpn_tcp/servers/nl542.nordvpn.com.tcp.ovpn
-  [[ -z ${1} ]] && return || true
   local nordvpn_cdn=${nordvpn_cdn}
-  #which protocol tcp or udp
-  if [[ ${NORDVPN_PROTOCOL,,} == tcp ]]; then
-    nordvpn_cdn="${nordvpn_cdn}/ovpn_tcp/servers/"
+  # remote filename: which protocol tcp or udp
+  if [[ ${NORDVPN_PROTOCOL,,} == udp ]]; then
+    nordvpn_cdn="${nordvpn_cdn}/ovpn_udp/servers/${1}.udp.ovpn"
+    ovpnName=${1}.ovpn
+  elif [[ ${NORDVPN_PROTOCOL,,} == tcp ]]; then
+    nordvpn_cdn="${nordvpn_cdn}/ovpn_tcp/servers/${1}.tcp.ovpn"
+    ovpnName=${1}.ovpn
   else
-    nordvpn_cdn="${nordvpn_cdn}/ovpn_udp/servers/"
-  fi
-
-  # default or defined server name
-  nordvpn_cdn=${nordvpn_cdn}${1}
-  ovpnName=${1}.ovpn
-
-  # remote filename
-  if [[ ${NORDVPN_PROTOCOL,,} == tcp ]]; then
-    nordvpn_cdn="${nordvpn_cdn}.tcp.ovpn"
-  else
-    nordvpn_cdn="${nordvpn_cdn}.udp.ovpn"
+    #Defaulting to tcp if neither tcp nor udp given.
+    nordvpn_cdn="${nordvpn_cdn}/ovpn_tcp/servers/${1}.tcp.ovpn"
+    ovpnName=${1}.ovpn
   fi
 
   log "INFO: OVPN: Downloading config: ${ovpnName}"
@@ -185,20 +211,18 @@ download_hostname() {
 }
 
 checkDNS() {
-  res=$(dig +short ${nordvpn_dl})
-  if [ -z "${res:-\"\"}" ]; then
-    log "ERROR: OVPN: no dns resolution, dns server unavailable or network problem"
+  res=$(dig +short ${nordvpn_dl})||true
+  if [[ ${res} == "" ]]; then
+    fatal_error "ERROR: OVPN: no dns resolution, dns server unavailable or network problem"
   else
     log "INFO: OVPN: DNS resolution ok"
   fi
-  ping -c2 ${nordvpn_dl} 2>&1 >/dev/null
-  ret=$?
-  if [ $ret -eq 0 ]; then
+  ret=$(ping -c2 ${nordvpn_dl} 2>&1)||true
+  if [[ $ret =~ \ 0%\ packet\ loss ]]; then
     log "INFO: OVPN: ok, configurations download site reachable"
   else
-    log "ERROR: OVPN: cannot ping ${nordvpn_cdn}, network or internet unavailable. Cannot download NORDVPN configuration files"
+    fatal_error "ERROR: OVPN: cannot ping ${nordvpn_cdn}, network or internet unavailable. Cannot download NORDVPN configuration files"
   fi
-  return $ret
 }
 
 # Main
@@ -212,9 +236,12 @@ if [[ -d ${VPN_PROVIDER_HOME} ]]; then
   find ${VPN_PROVIDER_HOME} -type f ! -name '*.sh' -delete
 fi
 
-#Tests NORDVPN_<COUNTRY, PROTOCOL, CATEGORY> values
-if [[ -n ${NORDVPN_TESTS:-""} ]]; then
+possible_categories="$(echo ${json_groups} | jq -r .[].identifier |tr '\n' ', ')"
+possible_country_codes="$(echo ${json_countries} | jq -r .[].code |tr '\n' ', ')"
+possible_country_names="$(echo ${json_countries} | jq -r .[].name |tr '\n' ', ')"
+possible_protocol="$(echo ${json_technologies} | jq -r '.[] | [.identifier, .name ]' |tr '\n' ', ' | grep openvpn)"
 
+if [[ -n ${NORDVPN_TESTS} ]]; then
   case ${NORDVPN_TESTS} in
   1)
     #get recommended config when no values are given, use defaults one, display a warning with possible values
@@ -240,7 +267,8 @@ if [[ -n ${NORDVPN_TESTS:-""} ]]; then
 fi
 
 #get config based on server name
-if [[ -n ${NORDVPN_SERVER:-""} ]]; then
+NORDVPN_SERVER=${NORDVPN_SERVER:-""}
+if [[ -n ${NORDVPN_SERVER} ]]; then
   selected=${NORDVPN_SERVER}
   load=$(curl -s ${nordvpn_api}/server/stats/${NORDVPN_SERVER} | jq .percent 2>/dev/null)
   log "INFO: OVPN: server : ${NORDVPN_SERVER}, load: ${load:-N/A}"
@@ -255,9 +283,8 @@ else
   log "Checking NORDPVN API responses"
   for po in json_countries json_groups json_technologies; do
     if [[ $(echo ${!po} | grep -c "<html>") -gt 0 ]]; then
-      msg=$(echo ${!po} | sed -E 's/.*title>([^\<]+).*/\1 /')
-      log "ERROR: OVPN: unexpected html content from NORDVPN servers: ${msg}"
-      log "ERROR: OVPN: NORDVPN API has a throttle limit, may return a 429 Too many messages, if container is in a loop of restart"
+      msg=$(echo ${!po} | grep -oP "(?<=title>)[^<]+")
+      echo "ERROR, unexpected html content from NORDVPN servers: ${msg}"
       sleep 30
       exit
     fi
@@ -271,6 +298,96 @@ else
   #get server name from api (best recommended for NORDVPN_<> if defined)
   selected="$(select_hostname)"
 fi
-[[ -n ${selected} ]] && download_hostname ${selected} || true
+if [[ -z ${selected} ]]; then
+  fatal_error "server compliant with your settings not found, review them"
+fi
+res="$(download_hostname ${selected})"
+
+log "OVPN: NORDVPN: selected: ${selected}, VPN_PROVIDER_HOME: ${VPN_PROVIDER_HOME}"
+# fix deprecated ciphers
+if [[ -f ${VPN_PROVIDER_HOME}/${selected}.ovpn ]]; then
+  #add data ciphers: DEPRECATED OPTION: --cipher set to 'AES-256-CBC' but missing in --data-ciphers (AES-256-GCM:AES-128-GCM).
+  if [[ 0 -le $(grep -c "cipher AES-256-CBC" ${VPN_PROVIDER_HOME}/${selected}.ovpn) ]] && [[ 0 -eq $(grep -c "data-ciphers AES-256-CBC" ${VPN_PROVIDER_HOME}/${selected}.ovpn) ]]; then
+      sed -i "/cipher AES-256-CBC/a data-ciphers AES-256-CBC" ${VPN_PROVIDER_HOME}/${selected}.ovpn
+  fi
+fi
+#handle tests results.
+if [[ -n ${NORDVPN_TESTS} ]]; then
+    msg=""
+    error=0
+    [[ ${res} -eq 0 ]] && res=$(<${VPN_PROVIDER_HOME}/${selected}.ovpn)
+    case ${NORDVPN_TESTS} in
+    1)
+      if [[ ${selected} =~  ${NORDVPN_REG} ]] ; then
+        msg+="\nOVPN/NORDVPN: test 1: OK: ${selected} matching expected ${NORDVPN_REG}"
+      else
+        error=1
+        msg+="\nOVPN/NORDVPN: test 1: KO: ${selected} not matching expected ${NORDVPN_REG}"
+      fi
+      if [[ $(echo $res | grep -c "proto tcp") -eq 0 ]]; then
+        error=1
+        msg+="\nOVPN/NORDVPN: test 1: KO: ${selected} is not with tcp protocol"
+        msg+="\n"${res}
+        else
+          msg+="\nOVPN/NORDVPN: test 1: OK: ${selected} is with tcp protocol"
+      fi
+    ;;
+    2)
+      if [[ ${selected} =~  ${NORDVPN_REG} ]] ; then
+        msg+="\nOVPN/NORDVPN: test 2: OK: ${selected} matching expected ${NORDVPN_REG}"
+      else
+        error=1
+        msg+="\nOVPN/NORDVPN: test 2: KO: ${selected} not matching expected ${NORDVPN_REG}"
+      fi
+      if [[ $(echo $res | grep -oc "proto udp") -eq 0 ]]; then
+        error=1
+        msg+="\nOVPN/NORDVPN: test 2: KO: ${selected} is not with udp protocol"
+        msg+="\n"${res}
+        else
+          msg+="\nOVPN/NORDVPN: test 2: OK: ${selected} is with udp protocol"
+      fi      ;;
+    3)
+      if [[ ${selected} =~  ${NORDVPN_REG} ]] ; then
+        msg+="\nOVPN/NORDVPN: test 3: OK: ${selected} matching expected ${NORDVPN_REG}"
+      else
+        error=1
+        msg+="\nOVPN/NORDVPN: test 3: KO: ${selected} not matching expected ${NORDVPN_REG}"
+      fi
+      if [[ $(echo $res | grep -oc "proto tcp") -eq 0 ]]; then
+        error=1
+        msg+="\nOVPN/NORDVPN: test 3: KO: ${selected} is not with tcp protocol"
+        msg+=${res}
+        else
+          msg+="\nOVPN/NORDVPN: test 3: OK: ${selected} is with tcp protocol"
+      fi
+      ;;
+    4)
+      if [[ ${selected} =~  ${NORDVPN_REG} ]] ; then
+        msg+="\nOVPN/NORDVPN: test 4: OK: ${selected} matching expected ${NORDVPN_REG}"
+      else
+        error=1
+        msg+="\nOVPN/NORDVPN: test 4: KO: ${selected} not matching expected ${NORDVPN_REG}"
+      fi
+      if [[ $(echo $res | grep -oc "proto tcp") -eq 0 ]]; then
+        error=1
+        msg+="\nOVPN/NORDVPN: test 4: KO: ${selected} is not with tcp protocol"
+        msg+=${res}
+        else
+          msg+="\nOVPN/NORDVPN: test 4: OK: ${selected} is with tcp protocol"
+      fi
+      ;;
+    *)
+    fatal_error "\nOVPN: NORDVPN: ${VPN_PROVIDER_HOME}/${selected}.ovpn not found"
+    esac
+    if [[ $error -eq 1 ]]; then
+      fatal_error ${msg}
+    else
+      log ${msg}
+    fi
+    fatal_error "OVPN: NORDVPN: end of test, container stopped."
+    [[ /.dockerinit ]] && pkill dumb_init || true
+fi
+
 export OPENVPN_CONFIG=${selected}
+
 cd "${0%/*}"

--- a/openvpn/ovpn/configure-openvpn.sh
+++ b/openvpn/ovpn/configure-openvpn.sh
@@ -37,6 +37,7 @@ cd /etc/openvpn/ovpn
 find /etc/openvpn/ovpn -type f ! -name "*.sh" -delete
 
 # Download and extract wanted bundle into temporary file
+
 echo "creating temp folder"
 mkdir /tmp/ovpnxtract/
 echo "entering temp folder"
@@ -46,6 +47,7 @@ echo "moving content"
 mv /tmp/ovpnxtract/vpn-configs-contrib/openvpn/ovpn/* /etc/openvpn/ovpn
 echo "deleting temp folder"
 rm -rf /tmp/ovpnxtract/
+
 
 
 #pattern=$OVPN_CONNECTION.$OVPN_COUNTRY.$OVPN_CITY.$OVPN_PROTOCOL

--- a/openvpn/persistEnvironment.py
+++ b/openvpn/persistEnvironment.py
@@ -43,9 +43,10 @@ for env_var in os.environ:
 
 # Dump resulting settings to file
 with open(args.env_var_script_file, 'w') as script_file:
+    script_file.write("#!/bin/bash\n")
     for var_name, var_value in variables_to_persist.items():
         script_file.write(
-            'export {env_var}={env_var_value}\n'.format(
+            'export {env_var}="{env_var_value}"\n'.format(
                 env_var=var_name,
                 env_var_value=var_value,
             ),

--- a/transmission/start.sh
+++ b/transmission/start.sh
@@ -56,6 +56,16 @@ if [[ "shift" = "$TRANSMISSION_WEB_UI" ]]; then
   export TRANSMISSION_WEB_HOME=/opt/transmission-ui/shift
 fi
 
+case ${TRANSMISSION_LOG_LEVEL,,} in
+  "trace" | "debug" | "info" | "warn" | "error" | "critical")
+    echo "Will exec Transmission with '--log-level=${TRANSMISSION_LOG_LEVEL,,}' argument"
+    export TRANSMISSION_LOGGING="--log-level=${TRANSMISSION_LOG_LEVEL,,}"
+    ;;
+  *)
+    export TRANSMISSION_LOGGING=""
+    ;;
+esac
+
 . /etc/transmission/userSetup.sh
 
 echo "Updating Transmission settings.json with values from env variables"
@@ -85,7 +95,9 @@ else
 fi
 
 echo "STARTING TRANSMISSION"
-exec su --preserve-environment ${RUN_AS} -s /bin/bash -c "/usr/local/bin/transmission-daemon -g ${TRANSMISSION_HOME} --logfile $LOGFILE" &
+
+exec su --preserve-environment ${RUN_AS} -s /bin/bash -c "/usr/local/bin/transmission-daemon ${TRANSMISSION_LOGGING} -g ${TRANSMISSION_HOME} --logfile $LOGFILE" &
+
 
 # Configure port forwarding if applicable
 if [[ -x /etc/openvpn/${OPENVPN_PROVIDER,,}/update-port.sh && (-z $DISABLE_PORT_UPDATER || "false" = "$DISABLE_PORT_UPDATER") ]]; then


### PR DESCRIPTION
* Quoute variables, fixes #2406 and #2418

* Fix sed busy (#2426)

* fix sed device or resource busy errors



* update info



* update docs



* log and fail if config is a mountpoint



* correct mountpoint check





* Fix fallback of transmission-home #2409

* Fix to use iptables-legacy rather than iptables-nft (#2456)

* Fix bug: the evironment file will be invalid (#2496)

something environment like:
`name=foo bar` 
will be invalid in the environment file, in a real example, it will be like `provider= SE Sto`.

Simply add change it to `provider="SE Sto"` will fix that.

* restart privoxy if docker changed eth0 address. (#2494)

* restart privoxy if docker changed eth0 address.

* sometimes, pidfile exists but process is dead

* Simplify RPC creds setup (#2480)

Reduce the complexity associated with creating RPC creds

* Fix bitwise decimal & octal (#2457)

* Fix bitwise decimal & octal

The issue is tracked here: https://github.com/haugene/docker-transmission-openvpn/issues/2450#issuecomment-1336259355

Also uses the TRASNMSISSION_UMASK variable instead of settings.json since updateSettings.py is called after userSetup.sh causing the TRANSMISSION_UMASK in settings.json to be stale when userSetup.sh accesses it.

* fix: missing {} in sh variable

* fix: missing {} in sh variable

* fix regex for webproxy enabled (#2505)

* review nordvpn error exit messages + tests (#2518)

* Check for files existing instead of being executable #2459

* Bump docker/build-push-action from 3 to 4 (#2522)

Bumps [docker/build-push-action](https://github.com/docker/build-push-action) from 3 to 4.
- [Release notes](https://github.com/docker/build-push-action/releases)
- [Commits](https://github.com/docker/build-push-action/compare/v3...v4)

---
updated-dependencies:
- dependency-name: docker/build-push-action dependency-type: direct:production update-type: version-update:semver-major ...




* fix: Add quotes on generated variables to avoid braking with spaces (#2538)

This should fix #2406

* Fix crash in fetch-external-configs on unset vars (#2561)

* simple adjustments to "openvpn/modify-openvpn-config.sh" and "transmission/start.sh" that can make the verbosity of logging user-adjustable (#2564)

* Bump docker/build-push-action from 3 to 4 (#2534)

Bumps [docker/build-push-action](https://github.com/docker/build-push-action) from 3 to 4.
- [Release notes](https://github.com/docker/build-push-action/releases)
- [Commits](https://github.com/docker/build-push-action/compare/v3...v4)

---
updated-dependencies:
- dependency-name: docker/build-push-action dependency-type: direct:production update-type: version-update:semver-major ...




* Socks5 example doc (#2541)

* fixing some heading sizes

* adding socks5-proxy example

---------



* Docs: add capabilities for Podman to tips&tricks (#2546)



* Change CONFIG_MOD_VERBOSITY usage

This change causes ${CONFIG_MOD_VERBOSITY} to become a variable used directly in the .ovpn config file.  The default value remains '3'.

* Insert ${TRANSMISSION_LOGGING} into exec'd command

This change allows for executing 'transmission-daemon' with '--log-level' set.  Utilizing a case-statement and forced lowercase, only valid values are accepted.  Default is no logging.

---------








* OVPN script fix for for 4.x branch  (#2566)

* Bump docker/build-push-action from 3 to 4 (#2534)

Bumps [docker/build-push-action](https://github.com/docker/build-push-action) from 3 to 4.
- [Release notes](https://github.com/docker/build-push-action/releases)
- [Commits](https://github.com/docker/build-push-action/compare/v3...v4)

---
updated-dependencies:
- dependency-name: docker/build-push-action dependency-type: direct:production update-type: version-update:semver-major ...




* Socks5 example doc (#2541)

* fixing some heading sizes

* adding socks5-proxy example

---------



* Docs: add capabilities for Podman to tips&tricks (#2546)



* git instead of unzip

git instead of unzip

* Using GIT

GIT is used now instead of UNZIP due to issues suddenly experienced.

---------








---------

<!--
  Please, vpn provider updates should ONLY be done at the new repo:
  https://github.com/haugene/vpn-configs-contrib
  No updates and such will be accepted here
-->
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  Also, please create PRs to DEV branch, !!NOT!! MASTER branch. 
  If necessary, when we review or such, 
  make a comment if you feel this needs to go to master directly, 
  otherwise, we will merge to master when necessary.
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Leave this section empty if this PR is NOT a breaking change.
-->
```txt
<placeholder>
```


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
```txt
<placeholder>
```


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this container)
- [ ] Breaking change (fix/feature causing existing functionality to break)


## Additional information
<!--
  Details are important, and help maintainers process your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: ```fixes #```
- This PR is related to issue: ```relates to #```
- Link to documentation updated (if done separately): ```https://...```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated

<!-- Please check *Preview* before submitting -->
