### PR TITLE
Add Transmissionic Web UI & New Documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,10 @@ RUN apk --no-cache add curl jq \
     && mv /opt/transmission-ui/kettu-master /opt/transmission-ui/kettu \
     && echo "Install Transmission-Web-Control" \
     && mkdir /opt/transmission-ui/transmission-web-control \
-    && curl -sL $(curl -s https://api.github.com/repos/ronggang/transmission-web-control/releases/latest | jq --raw-output '.tarball_url') | tar -C /opt/transmission-ui/transmission-web-control/ --strip-components=2 -xz
+    && curl -sL $(curl -s https://api.github.com/repos/ronggang/transmission-web-control/releases/latest | jq --raw-output '.tarball_url') | tar -C /opt/transmission-ui/transmission-web-control/ --strip-components=2 -xz \
+    && echo "Install Transmissionic" \
+    && wget -qO- https://github.com/6c65726f79/Transmissionic/releases/download/v1.8.0/Transmissionic-webui-v1.8.0.zip | unzip -q - \
+    && mv web /opt/transmission-ui/transmissionic
 
 
 FROM ubuntu:22.04 AS base
@@ -37,6 +40,7 @@ RUN set -ex; \
       libnatpmp-dev \
       libpsl-dev \
       libssl-dev
+
 
 FROM base as TransmissionBuilder
 

--- a/docs/config-options.md
+++ b/docs/config-options.md
@@ -82,13 +82,14 @@ This container comes bundled with some alternative Web UIs:
 * [Transmission-Web-Control](https://github.com/ronggang/transmission-web-control/)
 * [Flood for Transmission](https://github.com/johman10/flood-for-transmission)
 * [Shift](https://github.com/killemov/Shift)
+* [Transmissionic](https://github.com/6c65726f79/Transmissionic)
 
 To use one of them instead of the default Transmission UI you can set `TRANSMISSION_WEB_UI`
-to either `combustion`, `kettu`, `transmission-web-control`, `flood-for-transmission` or `shift` respectively.
+to either `combustion`, `kettu`, `transmission-web-control`, `flood-for-transmission`, `shift` or `transmissionic` respectively.
 
 | Variable                | Function                         | Example                                                                                                                                       |
 | ----------------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `TRANSMISSION_WEB_UI`   | Use the specified bundled web UI | `TRANSMISSION_WEB_UI=combustion` <br>`TRANSMISSION_WEB_UI=kettu` <br>`TRANSMISSION_WEB_UI=transmission-web-control` <br>`TRANSMISSION_WEB_UI=flood-for-transmission` <br>`TRANSMISSION_WEB_UI=shift` |
+| `TRANSMISSION_WEB_UI`   | Use the specified bundled web UI | `TRANSMISSION_WEB_UI=combustion` <br>`TRANSMISSION_WEB_UI=kettu` <br>`TRANSMISSION_WEB_UI=transmission-web-control` <br>`TRANSMISSION_WEB_UI=flood-for-transmission` <br>`TRANSMISSION_WEB_UI=shift` <br>`TRANSMISSION_WEB_UI=transmissionic` |
 
 ### User configuration options
 

--- a/transmission/start.sh
+++ b/transmission/start.sh
@@ -56,6 +56,11 @@ if [[ "shift" = "$TRANSMISSION_WEB_UI" ]]; then
   export TRANSMISSION_WEB_HOME=/opt/transmission-ui/shift
 fi
 
+if [[ "transmissionic" = "$TRANSMISSION_WEB_UI" ]]; then
+  echo "Using Transmissionic UI, overriding TRANSMISSION_WEB_HOME"
+  export TRANSMISSION_WEB_HOME=/opt/transmission-ui/transmissionic
+fi
+
 case ${TRANSMISSION_LOG_LEVEL,,} in
   "trace" | "debug" | "info" | "warn" | "error" | "critical")
     echo "Will exec Transmission with '--log-level=${TRANSMISSION_LOG_LEVEL,,}' argument"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR packages the open-source web UI [Transmissionic](https://github.com/6c65726f79/Transmissionic) as part of the Docker image. The Transmissionic project has 233 stars on GitHub at the time of writing, has received a commit in the last 30 days and describes itself as follows:

> Transmissionic is a free multi-platform remote for Transmission Daemon built with [Ionic](https://ionicframework.com/) and [Vue.js](https://vuejs.org/).
> It can be used as [Web Interface](https://github.com/transmission/transmission/wiki/Web-Interface), Android/iOS app and Windows/Linux/macOS program.

This project already includes several choices for web UIs. I feel that this particular web UI ought to be included as part of the official Docker image for the following reasons:

- It has a polished user experience and is mobile-friendly with a responsive layout.
- Based on my own testing, it seems to be compatible with the recent Transmission 4.0.2 release.
- The project is actively maintained.

Note: I am not associated with the Transmissionic project or it's maintainers in any way.


## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to this container)
- [ ] Breaking change (fix/feature causing existing functionality to break)


## Additional information
- Link to documentation updated (if done separately): ```https://haugene.github.io/docker-transmission-openvpn/config-options```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated