### PR TITLE
Privoxy eth0 fixes, healthcheck comparison tweak and start.sh update

### DIFF
--- a/privoxy/scripts/start.sh
+++ b/privoxy/scripts/start.sh
@@ -27,7 +27,7 @@ set_port()
   # Set the port for the IPv4 interface
   adr=$(ip -4  a show eth0| grep -oP "(?<=inet )([^/]+)")
   adr=${adr:-"0.0.0.0"}
-  sed -i -E "s/^listen-address\s+127.*/listen-address ${adr}:$1/" "$2"
+  sed -i -E "s/^listen-address\s+.*/listen-address ${adr}:$1/" "$2"
 
   # Remove the listen-address for IPv6 for now. IPv6 compatibility should come later
   sed -i -E "s/^listen-address\s+\[\:\:1.*//" "$2"

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -59,7 +59,7 @@ if [[ ${WEBPROXY_ENABLED} =~ [yY][eE]?[Ss]?|[tT][Rr][Uu][eE] ]]; then
   if [[ ${PROXY} -eq 0 ]]; then
     echo "Privoxy warning: process was stopped, restarting."
   fi
-    proxy_ip=$(grep -oP "(?<=^listen-address).*$" /etc/privoxy/config | sed 's/\:.*//' | sed 's/ //g')
+    proxy_ip=$(grep -oP "(?<=^listen-address )[0-9\.]+" /etc/privoxy/config)
     cont_ip=$(ip -j a show dev eth0 | jq -r .[].addr_info[].local)
     if [[ ${proxy_ip} != ${cont_ip} ]]; then
       echo "Privoxy error: container ip (${cont_ip} has changed: privoxy listening to ${proxy_ip}, restarting privoxy."

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -59,7 +59,7 @@ if [[ ${WEBPROXY_ENABLED} =~ [yY][eE]?[Ss]?|[tT][Rr][Uu][eE] ]]; then
   if [[ ${PROXY} -eq 0 ]]; then
     echo "Privoxy warning: process was stopped, restarting."
   fi
-    proxy_ip=$(grep -oP "(?<=^listen-address).*$" /etc/privoxy/config | sed 's/ //g')
+    proxy_ip=$(grep -oP "(?<=^listen-address).*$" /etc/privoxy/config | sed 's/\:.*//' | sed 's/ //g')
     cont_ip=$(ip -j a show dev eth0 | jq -r .[].addr_info[].local)
     if [[ ${proxy_ip} != ${cont_ip} ]]; then
       echo "Privoxy error: container ip (${cont_ip} has changed: privoxy listening to ${proxy_ip}, restarting privoxy."


### PR DESCRIPTION
<!--
  Please, vpn provider updates should ONLY be done at the new repo:
  https://github.com/haugene/vpn-configs-contrib
  No updates and such will be accepted here
-->
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  Also, please create PRs to DEV branch, !!NOT!! MASTER branch. 
  If necessary, when we review or such, 
  make a comment if you feel this needs to go to master directly, 
  otherwise, we will merge to master when necessary.
-->
## Breaking change

## Proposed change
```txt
I was having trouble with the privoxy running on a diff IP than what eth0 was reporting. 
In discovery, I noted that there were a couple of problems preventing the healthcheck 
mechanism from automatically fixing things.
These changes are intended to allow healthcheck.sh to successfully get
privoxy running again on correct eth0 IP.
```


## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this container)
- [ ] Breaking change (fix/feature causing existing functionality to break)


## Additional information
None

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated

<!-- Please check *Preview* before submitting -->
