### PR TITLE
Fix sed regex not assigning new IP when the container reboots

### DIFF
--- a/privoxy/scripts/start.sh
+++ b/privoxy/scripts/start.sh
@@ -27,7 +27,7 @@ set_port()
   # Set the port for the IPv4 interface
   adr=$(ip -4  a show eth0| grep -oP "(?<=inet )([^/]+)")
   adr=${adr:-"0.0.0.0"}
-  sed -i -E "s/^listen-address\s+127.*/listen-address ${adr}:$1/" "$2"
+  sed -i -E "s/^listen-address\s+(\b[0-9]{1,3}.){3}[0-9]{1,3}\b/listen-address ${adr}:$1/" "$2"
 
   # Remove the listen-address for IPv6 for now. IPv6 compatibility should come later
   sed -i -E "s/^listen-address\s+\[\:\:1.*//" "$2"


### PR DESCRIPTION
When a docker container restarts, `eth0` may receive a new IP address, causing the proxy to face issues binding to the correct listening address, as the previous 127.* IP has already been replaced by `sed` with the regex. The replacement works only once, as the configuration is changed and stored in the writable container layer. To reset the configuration and allow `sed` to replace any IP with the evaluated IP address, the container needs to be stopped and removed using `docker rm <container_id>`. This change ensures proper functioning of the proxy and addresses IP changes during container restarts as the new regex will replace any IP.

This merge request is still required even with the following `healthcheck.sh` script:
![image](https://github.com/haugene/docker-transmission-openvpn/assets/31008003/25dfaa17-82fd-43e8-abbb-599cc2a4846f)

The `healthcheck.sh` script currently only monitors changes in IP addresses and does not update the privoxy config file accordingly. To address this, I suggest modifying the sed regular expression in `privoxy/scripts/start.sh`. This change is essential since the script should always be executed as part of the default container executable (specified by the `CMD` instruction in the Dockerfile). This script runs before the `healthcheck.sh` script.

<!--
  Please, vpn provider updates should ONLY be done at the new repo:
  https://github.com/haugene/vpn-configs-contrib
  No updates and such will be accepted here
-->
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  Also, please create PRs to DEV branch, !!NOT!! MASTER branch. 
  If necessary, when we review or such, 
  make a comment if you feel this needs to go to master directly, 
  otherwise, we will merge to master when necessary.
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Leave this section empty if this PR is NOT a breaking change.
-->
```txt
This merge request should not affect users already using the privoxy http proxy.
```


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
```txt
The merge request allows users to continue to use privoxy immediately (before healthcheck) when the container restarts or the docker host reboots.
```


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this container)
- [ ] Breaking change (fix/feature causing existing functionality to break)


## Additional information
<!--
  Details are important, and help maintainers process your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: ```fixes #```
- This PR is related to issue: ```relates to #2489 ```
- Link to documentation updated (if done separately): ```https://...```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated

<!-- Please check *Preview* before submitting -->
