### PR TITLE
Make sed regular expression more specific 

### DIFF
--- a/privoxy/scripts/start.sh
+++ b/privoxy/scripts/start.sh
@@ -27,7 +27,7 @@ set_port()
   # Set the port for the IPv4 interface
   adr=$(ip -4  a show eth0| grep -oP "(?<=inet )([^/]+)")
   adr=${adr:-"0.0.0.0"}
-  sed -i -E "s/^listen-address\s+(\b[0-9]{1,3}.){3}[0-9]{1,3}\b/listen-address ${adr}:$1/" "$2"
+  sed -i -E "s/^listen-address\s+(\b[0-9]{1,3}.){3}[0-9]{1,3}\b:\d+/listen-address ${adr}:$1/" "$2"
 
   # Remove the listen-address for IPv6 for now. IPv6 compatibility should come later
   sed -i -E "s/^listen-address\s+\[\:\:1.*//" "$2"

--- a/privoxy/scripts/start.sh
+++ b/privoxy/scripts/start.sh
@@ -27,7 +27,7 @@ set_port()
   # Set the port for the IPv4 interface
   adr=$(ip -4  a show eth0| grep -oP "(?<=inet )([^/]+)")
   adr=${adr:-"0.0.0.0"}
-  sed -i -E "s/^listen-address\s+.*/listen-address ${adr}:$1/" "$2"
+  sed -i -E "s/^listen-address\s+(\b[0-9]{1,3}.){3}[0-9]{1,3}\b/listen-address ${adr}:$1/" "$2"
 
   # Remove the listen-address for IPv6 for now. IPv6 compatibility should come later
   sed -i -E "s/^listen-address\s+\[\:\:1.*//" "$2"


### PR DESCRIPTION
The regular expression `.*` replaces the listening address on both of the following lines in the default config:

```
listen-address  127.0.0.1:8118
listen-address  [::1]:8118
```
The next sed expression to remove ipv6 `sed -i -E "s/^listen-address\s+\[\:\:1.*//" "$2"` will not match anymore after the first sed command ran with `.*`
Privoxy will also try to bind to the same address twice, and will not work with this invalid configuration.

The log of image  `haugene/transmission-openvpn:dev` shows the following error message:
![image](https://github.com/haugene/docker-transmission-openvpn/assets/31008003/92746aad-41ea-4a5b-892e-3ff67a2e1653)


<!--
  Please, vpn provider updates should ONLY be done at the new repo:
  https://github.com/haugene/vpn-configs-contrib
  No updates and such will be accepted here
-->
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  Also, please create PRs to DEV branch, !!NOT!! MASTER branch. 
  If necessary, when we review or such, 
  make a comment if you feel this needs to go to master directly, 
  otherwise, we will merge to master when necessary.
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Leave this section empty if this PR is NOT a breaking change.
-->
```txt
N/A
```


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
```txt
Allows privoxy to bind correctly
```


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this container)
- [ ] Breaking change (fix/feature causing existing functionality to break)


## Additional information
<!--
  Details are important, and help maintainers process your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: ```fixes #```
- This PR is related to issue: ```relates to #```
- Link to documentation updated (if done separately): ```https://...```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated

<!-- Please check *Preview* before submitting -->
