### PR TITLE
Check IPv4 and IPv6 DNS records separately during health check

### DIFF
--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -22,12 +22,17 @@ then
 fi
 
 # Check DNS resolution works
-nslookup $HOST > /dev/null
+nslookup -q=a $HOST > /dev/null
 STATUS=$?
 if [[ ${STATUS} -ne 0 ]]
 then
-    echo "DNS resolution failed"
-    exit 1
+    nslookup -q=aaaa $HOST > /dev/null
+    STATUS=$?
+    if [[ ${STATUS} -ne 0 ]]
+    then
+        echo "DNS resolution failed"
+        exit 1
+    fi
 fi
 
 ping -c 2 -w 10 $HOST # Get at least 2 responses and timeout after 10 seconds


### PR DESCRIPTION
nslookup checks for IPv4 and IPv6 records in a single call by default. If either returns an explicit lookup error, healthcheck.sh will report a failure. If the upstream server is rejecting certain requests based on type, such as NordVPN filtering IPv6, healthcheck.sh may never be able to report healthy. Resolve by checking both a and aaaa records separately and only return a failure if both fail.

<!--
  Please, vpn provider updates should ONLY be done at the new repo:
  https://github.com/haugene/vpn-configs-contrib
  No updates and such will be accepted here
-->
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  Also, please create PRs to DEV branch, !!NOT!! MASTER branch. 
  If necessary, when we review or such, 
  make a comment if you feel this needs to go to master directly, 
  otherwise, we will merge to master when necessary.
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Leave this section empty if this PR is NOT a breaking change.
-->
no


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
nslookup checks for IPv4 and IPv6 records in a single call by default. If either returns an explicit lookup error, healthcheck.sh will report a failure. If the upstream server is rejecting certain requests based on type, such as NordVPN filtering IPv6, healthcheck.sh may never be able to report healthy. Resolve by checking both a and aaaa records separately and only return a failure if both fail.


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this container)
- [ ] Breaking change (fix/feature causing existing functionality to break)


## Additional information
<!--
  Details are important, and help maintainers process your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: ```fixes #2823```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated

<!-- Please check *Preview* before submitting -->
