### PR TITLE
use symlink instead of copy for credentials when using secrets

### DIFF
--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -201,7 +201,7 @@ if [[ -f /run/secrets/openvpn_creds ]]; then
   #write creds if no file or contents are not the same.
   if [[ ! -f /config/openvpn-credentials.txt ]] || [[ "$(cat /run/secrets/openvpn_creds)" != "$(cat /config/openvpn-credentials.txt)" ]]; then
     echo "Setting OpenVPN credentials..."
-    cp /run/secrets/openvpn_creds /config/openvpn-credentials.txt
+    ln -fs /run/secrets/openvpn_creds /config/openvpn-credentials.txt
   fi
 else
   # add OpenVPN user/pass
@@ -219,11 +219,13 @@ else
 fi
 
 if [[ -f /run/secrets/rpc_creds ]]; then
+  ln -fs /run/secrets/rpc_creds /config/transmission-credentials.txt
   export TRANSMISSION_RPC_USERNAME=$(head -1 /run/secrets/rpc_creds)
   export TRANSMISSION_RPC_PASSWORD=$(tail -1 /run/secrets/rpc_creds)
+else
+  echo "${TRANSMISSION_RPC_USERNAME}" > /config/transmission-credentials.txt
+  echo "${TRANSMISSION_RPC_PASSWORD}" >> /config/transmission-credentials.txt
 fi
-echo "${TRANSMISSION_RPC_USERNAME}" > /config/transmission-credentials.txt
-echo "${TRANSMISSION_RPC_PASSWORD}" >> /config/transmission-credentials.txt
 
 # Persist transmission settings for use by transmission-daemon
 export CONFIG="${CHOSEN_OPENVPN_CONFIG}"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  Also, please create PRs to DEV branch, !!NOT!! MASTER branch. 
  If necessary, when we review or such, 
  make a comment if you feel this needs to go to master directly, 
  otherwise, we will merge to master when necessary.
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Leave this section empty if this PR is NOT a breaking change.
-->
```txt
<placeholder>
```


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
```txt
Fixes #2874, I think.

The main goal is for the container to not copy the credentials when they're provided via docker secrets as it makes secrets available, bypassing the concept of the secrets.
```


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this container)
- [ ] Breaking change (fix/feature causing existing functionality to break)


## Additional information
<!--
  Details are important, and help maintainers process your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #2874 
- This PR is related to issue: ```relates to #```
- Link to documentation updated (if done separately): ```https://...```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated

<!-- Please check *Preview* before submitting -->

## Notes

I hope adding this section won't break anything and that everything else was filled correctly 🙏.
I don't know if the change from plain text to a symlink file when using secrets should be documented, if so I'll add it.

This config has been tested locally with
```yaml
secrets:
  openvpn_creds:
    file: "./secrets/ovpn-credentials.txt"
  rpc_creds:
    file: "./secrets/transmission-rpc-credentials.txt"

services:
  transmission:
    privileged: true
    build:
      context: .
      dockerfile: ./Dockerfile 
    # image: haugene/transmission-openvpn
    ports:
      - 9091:9091
    volumes:
      - ./DOCKER/data:/data
      - ./DOCKER/config:/config
    environment:
      OPENVPN_CONFIG: netherlands
      OPENVPN_PROVIDER: PIA
    secrets:
      - openvpn_creds
      - rpc_creds
```

VPN works fine but RPC login seems to not be active despite being detected
```
transmission-1  | TRANSMISSION_HOME is currently set to: /config/transmission-home
transmission-1  | Creating TUN device /dev/net/tun
transmission-1  | Using OpenVPN provider: PIA
transmission-1  | Running with VPN_CONFIG_SOURCE auto
transmission-1  | Provider PIA has a bundled setup script. Defaulting to internal config
transmission-1  | Executing setup script for PIA
transmission-1  | Downloading OpenVPN config bundle openvpn into temporary file /tmp/tmp.nlKfCKLDA4
transmission-1  | Extract OpenVPN config bundle into PIA directory /etc/openvpn/pia
transmission-1  | Starting OpenVPN using config netherlands.ovpn
transmission-1  | Modifying /etc/openvpn/pia/netherlands.ovpn for best behaviour in this container
transmission-1  | Modification: Point auth-user-pass option to the username/password file
transmission-1  | Modification: Change ca certificate path
transmission-1  | Modification: Change ping options
transmission-1  | Modification: Update/set resolv-retry to 15 seconds
transmission-1  | Modification: Change tls-crypt keyfile path
transmission-1  | Modification: Set output verbosity to 3
transmission-1  | Modification: Remap SIGUSR1 signal to SIGTERM, avoid OpenVPN restart loop
transmission-1  | Modification: Updating status for config failure detection
transmission-1  | Setting OpenVPN credentials...
transmission-1  | 2024-09-04 08:53:26 DEPRECATED OPTION: --cipher set to 'aes-128-cbc' but missing in --data-ciphers (AES-256-GCM:AES-128-GCM). Future OpenVPN version will ignore --cipher for cipher negotiations. Add 'aes-128-cbc' to --data-ciphers or change --cipher 'aes-128-cbc' to --data-ciphers-fallback 'aes-128-cbc' to silence this warning.
transmission-1  | 2024-09-04 08:53:26 WARNING: file '/config/openvpn-credentials.txt' is group or others accessible
transmission-1  | 2024-09-04 08:53:26 OpenVPN 2.5.9 x86_64-pc-linux-gnu [SSL (OpenSSL)] [LZO] [LZ4] [EPOLL] [PKCS11] [MH/PKTINFO] [AEAD] built on Jun 27 2024
transmission-1  | 2024-09-04 08:53:26 library versions: OpenSSL 3.0.2 15 Mar 2022, LZO 2.10
transmission-1  | 2024-09-04 08:53:26 NOTE: the current --script-security setting may allow this configuration to call user-defined scripts
transmission-1  | 2024-09-04 08:53:26 CRL: loaded 1 CRLs from file -----BEGIN X509 CRL-----
transmission-1  | MIICWDCCAUAwDQYJKoZIhvcNAQENBQAwgegxCzAJBgNVBAYTAlVTMQswCQYDVQQI
transmission-1  | EwJDQTETMBEGA1UEBxMKTG9zQW5nZWxlczEgMB4GA1UEChMXUHJpdmF0ZSBJbnRl
transmission-1  | cm5ldCBBY2Nlc3MxIDAeBgNVBAsTF1ByaXZhdGUgSW50ZXJuZXQgQWNjZXNzMSAw
transmission-1  | HgYDVQQDExdQcml2YXRlIEludGVybmV0IEFjY2VzczEgMB4GA1UEKRMXUHJpdmF0
transmission-1  | ZSBJbnRlcm5ldCBBY2Nlc3MxLzAtBgkqhkiG9w0BCQEWIHNlY3VyZUBwcml2YXRl
transmission-1  | aW50ZXJuZXRhY2Nlc3MuY29tFw0xNjA3MDgxOTAwNDZaFw0zNjA3MDMxOTAwNDZa
transmission-1  | MCYwEQIBARcMMTYwNzA4MTkwMDQ2MBECAQYXDDE2MDcwODE5MDA0NjANBgkqhkiG
transmission-1  | 9w0BAQ0FAAOCAQEAQZo9X97ci8EcPYu/uK2HB152OZbeZCINmYyluLDOdcSvg6B5
transmission-1  | jI+ffKN3laDvczsG6CxmY3jNyc79XVpEYUnq4rT3FfveW1+Ralf+Vf38HdpwB8EW
transmission-1  | B4hZlQ205+21CALLvZvR8HcPxC9KEnev1mU46wkTiov0EKc+EdRxkj5yMgv0V2Re
transmission-1  | ze7AP+NQ9ykvDScH4eYCsmufNpIjBLhpLE2cuZZXBLcPhuRzVoU3l7A9lvzG9mjA
transmission-1  | 5YijHJGHNjlWFqyrn1CfYS6koa4TGEPngBoAziWRbDGdhEgJABHrpoaFYaL61zqy
transmission-1  | MR6jC0K2ps9qyZAN74LEBedEfK7tBOzWMwr58A==
transmission-1  | -----END X509 CRL-----
transmission-1  |
transmission-1  | 2024-09-04 08:53:26 TCP/UDP: Preserving recently used remote address: [AF_INET]212.102.35.145:1198
transmission-1  | 2024-09-04 08:53:26 Socket Buffers: R=[212992->212992] S=[212992->212992]
transmission-1  | 2024-09-04 08:53:26 UDP link local: (not bound)
transmission-1  | 2024-09-04 08:53:26 UDP link remote: [AF_INET]212.102.35.145:1198
transmission-1  | 2024-09-04 08:53:27 TLS: Initial packet from [AF_INET]212.102.35.145:1198, sid=dab6dd5b 374d72b2
transmission-1  | 2024-09-04 08:53:27 WARNING: this configuration may cache passwords in memory -- use the auth-nocache option to prevent this
transmission-1  | 2024-09-04 08:53:27 VERIFY OK: depth=1, C=US, ST=CA, L=LosAngeles, O=Private Internet Access, OU=Private Internet Access, CN=Private Internet Access, name=Private Internet Access, emailAddress=secure@privateinternetaccess.com
transmission-1  | 2024-09-04 08:53:27 VERIFY KU OK
transmission-1  | 2024-09-04 08:53:27 Validating certificate extended key usage
transmission-1  | 2024-09-04 08:53:27 ++ Certificate has EKU (str) TLS Web Server Authentication, expects TLS Web Server Authentication
transmission-1  | 2024-09-04 08:53:27 VERIFY EKU OK
transmission-1  | 2024-09-04 08:53:27 VERIFY OK: depth=0, C=US, ST=CA, L=LosAngeles, O=Private Internet Access, OU=Private Internet Access, CN=amsterdam416, name=amsterdam416
transmission-1  | 2024-09-04 08:53:27 Control Channel: TLSv1.3, cipher TLSv1.3 TLS_AES_256_GCM_SHA384, peer certificate: 2048 bit RSA, signature: RSA-SHA512
transmission-1  | 2024-09-04 08:53:27 [amsterdam416] Peer Connection Initiated with [AF_INET]212.102.35.145:1198
transmission-1  | 2024-09-04 08:53:27 PUSH: Received control message: 'PUSH_REPLY,comp-lzo no,redirect-gateway def1,route-ipv6 2000::/3,dhcp-option DNS 10.0.0.243,route-gateway 10.15.112.1,topology subnet,ping 10,ping-restart 60,ifconfig 10.15.112.138 255.255.255.0,peer-id 17,cipher AES-128-GCM'
transmission-1  | 2024-09-04 08:53:27 OPTIONS IMPORT: timers and/or timeouts modified
transmission-1  | 2024-09-04 08:53:27 OPTIONS IMPORT: compression parms modified
transmission-1  | 2024-09-04 08:53:27 OPTIONS IMPORT: --ifconfig/up options modified
transmission-1  | 2024-09-04 08:53:27 OPTIONS IMPORT: route options modified
transmission-1  | 2024-09-04 08:53:27 OPTIONS IMPORT: route-related options modified
transmission-1  | 2024-09-04 08:53:27 OPTIONS IMPORT: --ip-win32 and/or --dhcp-option options modified  
transmission-1  | 2024-09-04 08:53:27 OPTIONS IMPORT: peer-id set
transmission-1  | 2024-09-04 08:53:27 OPTIONS IMPORT: adjusting link_mtu to 1625
transmission-1  | 2024-09-04 08:53:27 OPTIONS IMPORT: data channel crypto options modified
transmission-1  | 2024-09-04 08:53:27 Data Channel: using negotiated cipher 'AES-128-GCM'
transmission-1  | 2024-09-04 08:53:27 Outgoing Data Channel: Cipher 'AES-128-GCM' initialized with 128 bit key
transmission-1  | 2024-09-04 08:53:27 Incoming Data Channel: Cipher 'AES-128-GCM' initialized with 128 bit key
transmission-1  | 2024-09-04 08:53:27 net_route_v4_best_gw query: dst 0.0.0.0
transmission-1  | 2024-09-04 08:53:27 net_route_v4_best_gw result: via 172.21.0.1 dev eth0
transmission-1  | 2024-09-04 08:53:27 ROUTE_GATEWAY 172.21.0.1/255.255.0.0 IFACE=eth0 HWADDR=02:42:ac:15:00:02
transmission-1  | 2024-09-04 08:53:27 GDG6: remote_host_ipv6=n/a
transmission-1  | 2024-09-04 08:53:27 net_route_v6_best_gw query: dst ::
transmission-1  | 2024-09-04 08:53:27 sitnl_send: rtnl: generic error (-101): Network is unreachable
transmission-1  | 2024-09-04 08:53:27 ROUTE6: default_gateway=UNDEF
transmission-1  | 2024-09-04 08:53:27 TUN/TAP device tun0 opened
transmission-1  | 2024-09-04 08:53:27 net_iface_mtu_set: mtu 1500 for tun0
transmission-1  | 2024-09-04 08:53:27 net_iface_up: set tun0 up
transmission-1  | 2024-09-04 08:53:27 net_addr_v4_add: 10.15.112.138/24 dev tun0
transmission-1  | 2024-09-04 08:53:27 net_route_v4_add: 212.102.35.145/32 via 172.21.0.1 dev [NULL] table 0 metric -1
transmission-1  | 2024-09-04 08:53:27 net_route_v4_add: 0.0.0.0/1 via 10.15.112.1 dev [NULL] table 0 metric -1
transmission-1  | 2024-09-04 08:53:27 net_route_v4_add: 128.0.0.0/1 via 10.15.112.1 dev [NULL] table 0 metric -1
transmission-1  | 2024-09-04 08:53:27 WARNING: OpenVPN was configured to add an IPv6 route. However, no IPv6 has been configured for tun0, therefore the route installation may fail or may not work as expected.
transmission-1  | 2024-09-04 08:53:27 add_route_ipv6(2000::/3 -> :: metric -1) dev tun0
transmission-1  | 2024-09-04 08:53:27 net_route_v6_add: 2000::/3 via :: dev tun0 table 0 metric -1      
transmission-1  | Up script executed with device=tun0 ifconfig_local=10.15.112.138
transmission-1  | Updating TRANSMISSION_BIND_ADDRESS_IPV4 to the ip of tun0 : 10.15.112.138
transmission-1  | 
transmission-1  | -------------------------------------
transmission-1  | Transmission will run as
transmission-1  | -------------------------------------
transmission-1  | User name:   root
transmission-1  | User uid:    0
transmission-1  | User gid:    0
transmission-1  | -------------------------------------
transmission-1  |
transmission-1  | Updating Transmission settings.json with values from env variables
transmission-1  | Attempting to use existing settings.json for Transmission
transmission-1  | Could not read existing settings.json. Generating settings.json for Transmission from environment and defaults /etc/transmission/default-settings.json
transmission-1  | Overriding bind-address-ipv4 because TRANSMISSION_BIND_ADDRESS_IPV4 is set to 10.15.112.138
transmission-1  | Overriding download-dir because TRANSMISSION_DOWNLOAD_DIR is set to /data/completed   
transmission-1  | Overriding incomplete-dir because TRANSMISSION_INCOMPLETE_DIR is set to /data/incomplete
transmission-1  | Overriding rpc-password because TRANSMISSION_RPC_PASSWORD is set to [REDACTED]        
transmission-1  | Overriding rpc-port because TRANSMISSION_RPC_PORT is set to 9091
transmission-1  | Overriding rpc-username because TRANSMISSION_RPC_USERNAME is set to admin3333
transmission-1  | Overriding watch-dir because TRANSMISSION_WATCH_DIR is set to /data/watch
transmission-1  | sed'ing True to true
transmission-1  | STARTING TRANSMISSION
transmission-1  | Provider PIA has a script for automatic port forwarding. Will run it now.
transmission-1  | If you want to disable this, set environment variable DISABLE_PORT_UPDATER=true       
transmission-1  | Transmission startup script complete.
transmission-1  | 2024-09-04 08:53:27 Initialization Sequence Completed
transmission-1  | Running functions for token based port fowarding
transmission-1  | Reserved Port: 31011  Wed Sep  4 08:53:33 UTC 2024
transmission-1  | transmission auth not required
transmission-1  | waiting for transmission to become responsive
transmission-1  | transmission became responsive
transmission-1  |     ID   Done       Have  ETA           Up    Down  Ratio  Status       Name
transmission-1  | Sum:                None               0.0     0.0
transmission-1  | setting transmission port to 31011
transmission-1  | localhost:9091/transmission/rpc/ responded: success
transmission-1  | Checking port...
transmission-1  | Port is open: Yes
transmission-1  | #######################
transmission-1  |         SUCCESS
transmission-1  | #######################
transmission-1  | Port: 31011
transmission-1  | Expiration Tue Nov  5 20:53:13 UTC 2024
transmission-1  | #######################
transmission-1  | Entering infinite while loop
transmission-1  | Every 15 minutes, check port status
```
> transmission-1  | Overriding rpc-password because TRANSMISSION_RPC_PASSWORD is set to [REDACTED]    
> transmission-1  | Overriding rpc-username because TRANSMISSION_RPC_USERNAME is set to admin3333
> transmission-1  | transmission auth not required

The `settings.json` does include login infos:
```
    "rpc-enabled": true,
    "rpc-username": "admin3333",
    "rpc-password": "{c027720454b45cabdf1169bbd7d94d171c0f6e769b2hP2jw",
```
(credentials were set to `admin3333:12345`).

But I can't remember if its normal here or not (testing in local and accessing via localhost/IP via the same computer), will investigate further.
Couldn't explain it. Marking as ready so someone can see this and maybe exlpain.