### PR TITLE
pass --fail argument to curl to give more informative error message

### DIFF
--- a/openvpn/nordvpn/configure-openvpn.sh
+++ b/openvpn/nordvpn/configure-openvpn.sh
@@ -207,7 +207,7 @@ download_hostname() {
     log "INFO: OVPN: ${VPN_PROVIDER_HOME} is not writable, outputing ${ovpnName} to stdout"
     outfile=""
   fi
-  curl -sSL ${nordvpn_cdn} ${outfile}
+  curl -sSL --fail ${nordvpn_cdn} ${outfile}
 }
 
 checkDNS() {


### PR DESCRIPTION
<!--
  Please, vpn provider updates should ONLY be done at the new repo:
  https://github.com/haugene/vpn-configs-contrib
  No updates and such will be accepted here
-->
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  Also, please create PRs to DEV branch, !!NOT!! MASTER branch. 
  If necessary, when we review or such, 
  make a comment if you feel this needs to go to master directly, 
  otherwise, we will merge to master when necessary.
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Leave this section empty if this PR is NOT a breaking change.
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
My container was exiting with the error message:
```
Options error: Unrecognized option or missing or extra parameter(s) in /etc/openvpn/nordvpn/xxxx.nordvpn.com.ovpn:1: html
Use --help for more information.
exit code: 1
```
and after some debugging it turned out that the server URL I was passing was no longer valid and so the download ovpn file is not a valid configuration but instead a 404 HTML page.

This PR passes the `--fail` argument to curl which makes the error more informative in this case. For example when downloading an invalid server (uk0000):
```
$ curl -sSL --fail https://downloads.nordcdn.com/configs/files/ovpn_udp/servers/uk000.nordvpn.com.udp.ovpn -o foo
curl: (22) The requested URL returned error: 404
```

Note: I only added the flag to the command to download from nordvpn but I think it would make sense to use `--fail` everywhere. I can make this change if you want.

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to this container)
- [ ] Breaking change (fix/feature causing existing functionality to break)


## Additional information
<!--
  Details are important, and help maintainers process your PR.
  Please be sure to fill out additional details, if applicable.
-->


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated

<!-- Please check *Preview* before submitting -->
