### PR TITLE
Prevent error "Too many open files (24)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,10 @@ ADD privoxy/scripts /opt/privoxy/
 RUN update-alternatives --set iptables $(which iptables-legacy) && \
     update-alternatives --set ip6tables $(which ip6tables-legacy)
 
+# Prevent error "Too many open files (24)"
+RUN echo "abc soft nofile 65536" > /etc/security/limits.d/transmission.conf && \
+    echo "abc hard nofile 1048576" >> /etc/security/limits.d/transmission.conf
+
 ENV OPENVPN_USERNAME=**None** \
     OPENVPN_PASSWORD=**None** \
     OPENVPN_PROVIDER=**None** \


### PR DESCRIPTION
When having many torrents downloading at the same time, Transmission is known
to throw the error "Too many open files (24)", and stop torrents. This happens
when it hits the process limit for number of file descriptors simulatenously open.

This is because, in this Docker container, the launch of transmission as user `abc`
entails a default limit of 1024 open files.

Create the file `/etc/security/limits.d/transmission.conf` and adding some lines
for that user increases this limit to 65536 soft and 1048576 hard, which should
be enough for most use cases.
