### PR TITLE
Gracefully fall back to local configs when GitHub is unreachable

### DIFF
--- a/openvpn/fetch-external-configs.sh
+++ b/openvpn/fetch-external-configs.sh
@@ -60,12 +60,16 @@ elif [[ "${VPN_CONFIG_SOURCE_TYPE}" == "github_clone" ]]; then
     GITHUB_CONFIG_SOURCE_LOCAL=$(git -C "${config_repo}" remote -v | head -1 | awk '{print $2}' | sed -e 's/https:\/\/github.com\///' -e 's/.git//')
     if [ "$GITHUB_CONFIG_SOURCE_LOCAL" == "$GITHUB_CONFIG_SOURCE_REPO" ]; then
       echo "Repository is already cloned, updating"
-      if git -C "${config_repo}" fetch origin && \
-         git -C "${config_repo}" reset --hard origin/${GITHUB_CONFIG_SOURCE_REVISION} && \
-         git -C "${config_repo}" clean -fd; then
-        echo "Repository updated successfully"
+      if git -C "${config_repo}" fetch origin; then
+        if git -C "${config_repo}" reset --hard "origin/${GITHUB_CONFIG_SOURCE_REVISION}" && \
+           git -C "${config_repo}" clean -fd; then
+          echo "Repository updated successfully"
+        else
+          echo "ERROR: Fetched from origin but failed to reset to ${GITHUB_CONFIG_SOURCE_REVISION} or clean ${config_repo}"
+          exit 1
+        fi
       else
-        echo "WARNING: Failed to update configs from ${GITHUB_CONFIG_REPO_URL}, continuing with existing local configs"
+        echo "WARNING: Could not fetch from ${GITHUB_CONFIG_REPO_URL} (network or GitHub unavailable); continuing with existing local configs"
       fi
     else
       echo "Cloning ${GITHUB_CONFIG_REPO_URL} into ${config_repo}"


### PR DESCRIPTION
  ## Summary
  Fixes #2980
  When the VPN config repo is already cloned locally and the container 
  restarts, the startup script tries to `git fetch` the latest configs. If 
  GitHub is unreachable (500 error, network outage, etc.), `set -o errexit` 
  causes the script to exit and the container fails to start — even though
  usable configs already exist locally.
  This wraps the git update commands in an `if` block so that failures fall 
  back to the existing local configs with a warning, instead of crashing.
  Fresh clones (no local repo yet, or repo URL changed) still fail hard, as
  there is no local fallback in those cases.
