### PR TITLE
feat(docker): restore Transmission Web Control option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,11 @@ RUN apk --no-cache add curl jq \
     && mv /opt/transmission-ui/kettu-master /opt/transmission-ui/kettu \
     && echo "Install Transmissionic" \
     && wget -qO- https://github.com/6c65726f79/Transmissionic/releases/download/v1.8.0/Transmissionic-webui-v1.8.0.zip | unzip -q - \
-    && mv web /opt/transmission-ui/transmissionic
+    && mv web /opt/transmission-ui/transmissionic \
+    && echo "Install Transmission Web Control" \
+    && wget -qO- https://github.com/ronggang/transmission-web-control/archive/v1.6.1-update1.tar.gz | tar xz -C /opt/transmission-ui \
+    && mv /opt/transmission-ui/transmission-web-control-1.6.1-update1/src /opt/transmission-ui/transmission-web-control \
+    && rm -rf /opt/transmission-ui/transmission-web-control-1.6.1-update1
 
 # Build the image
 FROM ubuntu:24.04

--- a/transmission/start.sh
+++ b/transmission/start.sh
@@ -42,7 +42,8 @@ if [[ "kettu" = "$TRANSMISSION_WEB_UI" ]]; then
 fi
 
 if [[ "transmission-web-control" = "$TRANSMISSION_WEB_UI" ]]; then
-  echo "ERROR: transmission-web-control was removed in v5.4.0. Falling back to default UI."
+  echo "Using Transmission Web Control UI, overriding TRANSMISSION_WEB_HOME"
+  export TRANSMISSION_WEB_HOME=/opt/transmission-ui/transmission-web-control
 fi
 
 if [[ "flood-for-transmission" = "$TRANSMISSION_WEB_UI" ]]; then


### PR DESCRIPTION
## Breaking change
```txt
N/A
```

## Proposed change

Transmission Web Control was removed as a bundled UI option because the download URL was returning 404s. In 2025 the image switched from the original author's repo (`ronggang/transmission-web-control`) to a community fork under the `transmission-web-control` organization. That fork subsequently went dead, causing the 404s that led to removal.

This PR restores Transmission Web Control by pinning to a known-good release (`v1.6.1-update1`) from the original author's repo (`ronggang/transmission-web-control`), which remains up. Pinning to a specific tag avoids the fragility of fetching "latest" from a repo that may not be actively releasing.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information
- This PR is related to issue: #3000 #3003 https://github.com/haugene/docker-transmission-openvpn/commit/587443d5c7d0de8309411a7e9ab7db5e02715b35

## Checklist
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.