### PR TITLE
Add TrguiNG WebUI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@ RUN apk --no-cache add curl jq \
     && echo "Install Transmission Web Control" \
     && wget -qO- https://github.com/ronggang/transmission-web-control/archive/v1.6.1-update1.tar.gz | tar xz -C /opt/transmission-ui \
     && mv /opt/transmission-ui/transmission-web-control-1.6.1-update1/src /opt/transmission-ui/transmission-web-control \
-    && rm -rf /opt/transmission-ui/transmission-web-control-1.6.1-update1
+    && rm -rf /opt/transmission-ui/transmission-web-control-1.6.1-update1 \
+    && echo "Install TrguiNG" \
+    && wget -qO- https://github.com/openscopeproject/TrguiNG/releases/download/v1.5.1/trguing-web-v1.5.1.zip | unzip -q -d /opt/transmission-ui/trguing -
 
 # Build the image
 FROM ubuntu:24.04

--- a/docs/config-options.md
+++ b/docs/config-options.md
@@ -82,13 +82,14 @@ This container comes bundled with some alternative Web UIs:
 * [Flood for Transmission](https://github.com/johman10/flood-for-transmission)
 * [Shift](https://github.com/killemov/Shift)
 * [Transmissionic](https://github.com/6c65726f79/Transmissionic)
+* [TrguiNG](https://github.com/openscopeproject/TrguiNG)
 
 To use one of them instead of the default Transmission UI you can set `TRANSMISSION_WEB_UI`
-to either `combustion`, `kettu`, `transmission-web-control`, `flood-for-transmission`, `shift` or `transmissionic` respectively.
+to either `combustion`, `kettu`, `transmission-web-control`, `flood-for-transmission`, `shift`, `transmissionic` or `trguing` respectively.
 
 | Variable                | Function                         | Example                                                                                                                                       |
 | ----------------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `TRANSMISSION_WEB_UI`   | Use the specified bundled web UI | `TRANSMISSION_WEB_UI=combustion` <br>`TRANSMISSION_WEB_UI=kettu` <br>`TRANSMISSION_WEB_UI=transmission-web-control` <br>`TRANSMISSION_WEB_UI=flood-for-transmission` <br>`TRANSMISSION_WEB_UI=shift` <br>`TRANSMISSION_WEB_UI=transmissionic` |
+| `TRANSMISSION_WEB_UI`   | Use the specified bundled web UI | `TRANSMISSION_WEB_UI=combustion` <br>`TRANSMISSION_WEB_UI=kettu` <br>`TRANSMISSION_WEB_UI=transmission-web-control` <br>`TRANSMISSION_WEB_UI=flood-for-transmission` <br>`TRANSMISSION_WEB_UI=shift` <br>`TRANSMISSION_WEB_UI=transmissionic` <br>`TRANSMISSION_WEB_UI=trguing` |
 
 ### User configuration options
 

--- a/transmission/start.sh
+++ b/transmission/start.sh
@@ -61,6 +61,11 @@ if [[ "transmissionic" = "$TRANSMISSION_WEB_UI" ]]; then
   export TRANSMISSION_WEB_HOME=/opt/transmission-ui/transmissionic
 fi
 
+if [[ "trguing" = "$TRANSMISSION_WEB_UI" ]]; then
+  echo "Using TrguiNG UI, overriding TRANSMISSION_WEB_HOME"
+  export TRANSMISSION_WEB_HOME=/opt/transmission-ui/trguing
+fi
+
 case ${TRANSMISSION_LOG_LEVEL,,} in
   "trace" | "debug" | "info" | "warn" | "error" | "critical")
     echo "Will exec Transmission with '--log-level=${TRANSMISSION_LOG_LEVEL,,}' argument"


### PR DESCRIPTION
## Proposed change

This PR adds support for [TrguiNG](https://github.com/openscopeproject/TrguiNG?tab=readme-ov-file#how-to-use-trguing-as-a-web-interface), a modern and feature-rich WebUI for Transmission. 

The `Dockerfile` has been updated to download and extract the TrguiNG web assets into the `/opt/transmission-ui/trguing` directory during the build process. This provides users with another excellent alternative UI option that can be used by setting the `TRANSMISSION_WEB_UI=trguing` environment variable


## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to this container)
- [ ] Breaking change (fix/feature causing existing functionality to break)

## Checklist
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated
